### PR TITLE
Comment out template listing

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,7 +62,8 @@ st.caption(
 # Debug info (for admins)
 # st.write("📂 Current working directory:", os.getcwd())
 try:
-    st.write("📄 Available templates:", os.listdir("templates"))
+    # st.write("📄 Available templates:", os.listdir("templates"))  # Uncomment for debugging
+    pass
 except Exception:
     pass
 


### PR DESCRIPTION
## Summary
- disable listing templates in the app sidebar

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_687a84f063c48333b8a29574a9a8e85a