### PR TITLE
Add template management UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,18 @@ import json
 import streamlit as st
 import pandas as pd
 
+# Helper to validate uploaded template structure
+def validate_template_json(data: dict):
+    if not isinstance(data, dict):
+        return False, "Template must be a JSON object"
+    required = ["template_name", "fields", "accounts"]
+    for k in required:
+        if k not in data:
+            return False, f"Missing key '{k}'"
+    if not isinstance(data.get("fields"), list) or not isinstance(data.get("accounts"), list):
+        return False, "'fields' and 'accounts' must be lists"
+    return True, ""
+
 # Expose API key from Streamlit secrets for OpenAI
 if "OPENAI_API_KEY" in st.secrets:
     os.environ["OPENAI_API_KEY"] = st.secrets["OPENAI_API_KEY"]
@@ -36,6 +48,47 @@ with st.sidebar:
         st.session_state["uploaded_file"] = None
         st.session_state["client_id"] = ""
         st.experimental_rerun()
+
+    st.markdown("---")
+    st.subheader("Template Manager")
+
+    uploaded_template = st.file_uploader(
+        "Upload Template JSON", type=["json"], key="template_upload")
+    if uploaded_template is not None:
+        try:
+            data = json.load(uploaded_template)
+            ok, msg = validate_template_json(data)
+            if ok:
+                safe_name = "".join(
+                    c if c.isalnum() or c in "-_" else "_" for c in data["template_name"]
+                )
+                os.makedirs("templates", exist_ok=True)
+                with open(os.path.join("templates", f"{safe_name}.json"), "w") as f:
+                    json.dump(data, f, indent=2)
+                st.success(f"Saved template '{safe_name}'")
+                st.experimental_rerun()
+            else:
+                st.error(f"Invalid template: {msg}")
+        except Exception as e:
+            st.error(f"Failed to read JSON: {e}")
+
+    with st.expander("Existing Templates", expanded=False):
+        tmpl_files = [f for f in os.listdir("templates") if f.endswith(".json")]
+        for tf in tmpl_files:
+            c1, c2, c3 = st.columns([2, 1, 1])
+            tmpl_name = tf[:-5]
+            c1.write(tmpl_name)
+            with open(os.path.join("templates", tf)) as f:
+                c2.download_button(
+                    "Download",
+                    data=f.read(),
+                    file_name=tf,
+                    mime="application/json",
+                    key=f"dl_{tf}"
+                )
+            if c3.button("Delete", key=f"del_{tf}"):
+                os.remove(os.path.join("templates", tf))
+                st.experimental_rerun()
 
 # Overview instructions
 with st.expander("Help", expanded=True):


### PR DESCRIPTION
## Summary
- allow uploading template JSON files in sidebar
- validate uploaded templates and save to `templates/`
- list templates with download and delete actions

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a85ab784c8333808152d0677c720b