### PR TITLE
Improve sidebar progress tracker

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from utils.mapping_utils import (
     load_account_corrections,
     save_account_corrections,
 )
+from utils.ui_utils import render_progress, compute_current_step, STEPS
 
 # Streamlit config
 st.set_page_config(page_title="AI Mapping Agent", layout="wide")
@@ -56,16 +57,18 @@ except Exception:
     pass
 
 # Step progress indicator
-STEPS = ["Upload File", "Map Headers", "Match Account Names"]
-if "current_step" not in st.session_state:
-    st.session_state["current_step"] = 0
-st.progress(st.session_state["current_step"] / len(STEPS))
+st.session_state["current_step"] = compute_current_step()
+progress_container = st.sidebar.empty()
+render_progress(progress_container)
 
 # File upload
 st.header("1. Upload Client File")
-uploaded = st.file_uploader("Choose an Excel file", type=["xls","xlsx","xlsm"])
+uploaded = st.file_uploader(
+    "Choose an Excel file", type=["xls", "xlsx", "xlsm"], key="uploaded_file"
+)
 if uploaded:
-    st.session_state["current_step"] = 1
+    # store for later sessions
+    st.session_state["uploaded_file"] = uploaded
 else:
     st.stop()
 
@@ -140,7 +143,8 @@ if tmpl_name:
                 save_header_corrections(client_id, tmpl_name, corrections)
             st.session_state["header_suggestions"] = updated
             st.session_state["header_confirmed"] = True
-            st.session_state["current_step"] = 2
+            st.session_state["current_step"] = compute_current_step()
+            render_progress(progress_container)
             st.success("✅ Header mappings confirmed")
 
     # Final header mappings view
@@ -205,7 +209,9 @@ if tmpl_name:
                 if corrections:
                     save_account_corrections(client_id, tmpl_name, corrections)
                 st.session_state["account_suggestions"] = updated_acc
-                st.session_state["current_step"] = 3
+                st.session_state["account_confirmed"] = True
+                st.session_state["current_step"] = compute_current_step()
+                render_progress(progress_container)
                 st.success("✅ Account mappings confirmed")
 
                 # Aggregate confirmed mappings

--- a/pages/Template_Manager.py
+++ b/pages/Template_Manager.py
@@ -1,6 +1,7 @@
 import os
 import json
 import streamlit as st
+from utils.ui_utils import render_progress, compute_current_step
 
 # Helper to validate uploaded template structure
 
@@ -16,6 +17,9 @@ def validate_template_json(data: dict):
     return True, ""
 
 st.title("Template Manager")
+st.session_state["current_step"] = compute_current_step()
+progress_container = st.sidebar.empty()
+render_progress(progress_container)
 
 with st.sidebar:
     if st.button("Reset"):
@@ -23,9 +27,9 @@ with st.sidebar:
             "header_suggestions",
             "header_confirmed",
             "account_suggestions",
+            "account_confirmed",
         ]:
             st.session_state.pop(k, None)
-        st.session_state["current_step"] = 0
         st.session_state["uploaded_file"] = None
         st.session_state["client_id"] = ""
         st.experimental_rerun()

--- a/utils/ui_utils.py
+++ b/utils/ui_utils.py
@@ -1,0 +1,48 @@
+import streamlit as st
+
+# Steps used across the application
+STEPS = ["Upload File", "Map Headers", "Match Account Names"]
+
+
+def compute_current_step() -> int:
+    """Determine which step the user is currently on."""
+    if st.session_state.get("account_confirmed"):
+        return 3
+    if st.session_state.get("header_confirmed"):
+        return 2
+    if st.session_state.get("uploaded_file") is not None:
+        return 1
+    return 0
+
+
+def render_progress(container: st.delta_generator.DeltaGenerator | None = None):
+    """Render a persistent sidebar progress indicator."""
+    current = st.session_state.get("current_step", 0)
+    styles = """
+    <style>
+    .progress-list{position:relative;margin-left:20px;}
+    .progress-list::before{content:"";position:absolute;left:-8px;top:0;bottom:0;width:4px;background:#ccc;}
+    .step{position:relative;padding-left:12px;margin-bottom:0.5rem;}
+    .step.completed{color:#000;}
+    .step.current{font-weight:bold;color:#000;background:rgba(0,128,0,0.1);border-radius:4px;}
+    .step.todo{color:#999;}
+    .step::before{content:"";position:absolute;left:-12px;top:4px;width:8px;height:8px;border-radius:50%;background:#ccc;}
+    .step.completed::before{background:#28a745;}
+    .step.current::before{background:#28a745;animation:pulse 2s infinite;}
+    @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(40,167,69,0.7);}70%{box-shadow:0 0 0 8px rgba(40,167,69,0);}100%{box-shadow:0 0 0 0 rgba(40,167,69,0);}}
+    </style>
+    """
+    target = container if container is not None else st.sidebar
+    with target:
+        st.markdown(styles, unsafe_allow_html=True)
+        st.subheader("Progress")
+        st.markdown('<div class="progress-list">', unsafe_allow_html=True)
+        for i, step in enumerate(STEPS, start=1):
+            if current > i:
+                cls = "completed"
+            elif current == i:
+                cls = "current"
+            else:
+                cls = "todo"
+            st.markdown(f'<div class="step {cls}">{step}</div>', unsafe_allow_html=True)
+        st.markdown('</div>', unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- refactor progress utilities and compute current step in utils
- show progress tracker via placeholder so it updates immediately
- update header & account completion logic
- enhance sidebar tracker styling and vertical progress display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a8e7e8c088333afc4cdb3e1a21a53