### PR TITLE
Fix session state error when uploading file

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,10 +66,7 @@ st.header("1. Upload Client File")
 uploaded = st.file_uploader(
     "Choose an Excel file", type=["xls", "xlsx", "xlsm"], key="uploaded_file"
 )
-if uploaded:
-    # store for later sessions
-    st.session_state["uploaded_file"] = uploaded
-else:
+if not uploaded:
     st.stop()
 
 # Parse file and preview


### PR DESCRIPTION
## Summary
- avoid assigning to `st.session_state["uploaded_file"]` after creating file uploader

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687ac0e049008333a576f6481b240055