### PR TITLE
Fix sidebar navigation and template listing robustness

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,10 +61,10 @@ st.session_state["current_step"] = compute_current_step()
 progress_container = st.sidebar.empty()
 render_progress(progress_container)
 
-with st.sidebar:
-    st.page_link("app.py", label="Mapping Tool", icon="🗺️")
-    st.page_link("pages/Template_Manager.py", label="Template Manager", icon="🗂️")
-    st.markdown("---")
+# The built-in page navigator already lists available pages. We avoid custom
+# `st.page_link` calls to prevent duplication and compatibility issues across
+# Streamlit versions.
+
 
 # File upload
 st.header("1. Upload Client File")
@@ -88,6 +88,9 @@ st.dataframe(pd.DataFrame(records).head())
 
 # Template selection
 st.header("2. Select Template & Map Headers")
+# Ensure the templates directory exists in case this is the first run or a
+# fresh deployment without any templates yet.
+os.makedirs("templates", exist_ok=True)
 templates = [f[:-5] for f in os.listdir("templates") if f.endswith(".json")]
 tmpl_name = st.selectbox("Choose a template", templates)
 

--- a/pages/Template_Manager.py
+++ b/pages/Template_Manager.py
@@ -22,8 +22,8 @@ progress_container = st.sidebar.empty()
 render_progress(progress_container)
 
 with st.sidebar:
-    st.page_link("app.py", label="Mapping Tool", icon="🗺️")
-    st.page_link("pages/Template_Manager.py", label="Template Manager", icon="🗂️")
+    # Use Streamlit's built-in page navigation and avoid custom page links that
+    # can fail on older versions or cause duplicate menus.
     st.markdown("---")
     if st.button("Reset"):
         for k in [
@@ -61,6 +61,9 @@ with st.sidebar:
             st.error(f"Failed to read JSON: {e}")
 
     with st.expander("Existing Templates", expanded=False):
+        # Ensure the templates directory exists to avoid FileNotFoundError on
+        # first run or in a clean deployment.
+        os.makedirs("templates", exist_ok=True)
         tmpl_files = [f for f in os.listdir("templates") if f.endswith(".json")]
         for tf in tmpl_files:
             c1, c2, c3 = st.columns([2, 1, 1])


### PR DESCRIPTION
## Summary
- remove custom `st.page_link` calls that caused errors on deployment
- rely on built-in Streamlit navigation to avoid duplicate menus
- ensure the `templates` directory exists before listing files

## Testing
- `python -m py_compile app.py pages/Template_Manager.py app_utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687ac60ca7e48333a48b4e8942ed7ab2