### PR TITLE
Add confidence scores to header suggestions

### DIFF
--- a/tests/test_header_mapping.py
+++ b/tests/test_header_mapping.py
@@ -1,0 +1,20 @@
+import pytest
+
+from app_utils.mapping_utils import suggest_header_mapping
+
+
+def test_header_mapping_confidence():
+    fields = ["Balance", "Amount"]
+    cols = ["balance", "amount"]
+    res = suggest_header_mapping(fields, cols)
+    assert res["Balance"]["src"] == "balance"
+    assert res["Balance"]["confidence"] == 1.0
+    assert res["Amount"]["src"] == "amount"
+    assert res["Amount"]["confidence"] == 1.0
+
+
+def test_header_mapping_no_match():
+    res = suggest_header_mapping(["Date"], ["amount"])
+    assert res["Date"] == {}
+
+


### PR DESCRIPTION
## Summary
- enhance header mapping suggestions with similarity confidence
- support fuzzy header detection via difflib
- show confidence badges for suggestions
- add unit tests for header mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883dd76ce00833397e166d9f89aec8d