### PR TITLE
Add GPT auto-mapping

### DIFF
--- a/pages/steps/lookup.py
+++ b/pages/steps/lookup.py
@@ -7,6 +7,7 @@ import streamlit as st
 import pandas as pd
 
 from app_utils.mapping_utils import match_lookup_values
+from app_utils.mapping.lookup_layer import gpt_lookup_completion
 from app_utils.excel_utils import read_tabular_file
 from schemas.template_v2 import Template
 
@@ -69,6 +70,17 @@ def render(layer, idx: int):
     unmapped = [k for k, v in mapping.items() if v == ""]
     if unmapped:
         st.warning(f"{len(unmapped)} values still unmapped.")
+        if st.button("Auto-map Unmapped", key=f"automap_{idx}"):
+            try:
+                with st.spinner("Querying GPT..."):
+                    suggestions = gpt_lookup_completion(unmapped, dict_values)
+                for src, match in suggestions.items():
+                    if match:
+                        mapping[src] = match
+                st.session_state[key_map] = mapping
+                st.rerun()
+            except Exception as e:
+                st.error(str(e))
     else:
         st.success("All values mapped!")
 

--- a/tests/test_lookup_layer.py
+++ b/tests/test_lookup_layer.py
@@ -1,0 +1,26 @@
+import json
+import os
+import openai
+from app_utils.mapping.lookup_layer import gpt_lookup_completion
+
+
+def test_gpt_lookup_completion(monkeypatch):
+    class FakeResp:
+        def __init__(self, content):
+            self.choices = [type("c", (), {"message": type("m", (), {"content": content})()})()]
+
+    class FakeCompletions:
+        def create(self, model, messages, temperature):
+            data = {"A": "B"}
+            return FakeResp(json.dumps(data))
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.chat = type("chat", (), {"completions": FakeCompletions()})()
+
+    monkeypatch.setattr(openai, "OpenAI", lambda api_key=None: FakeClient())
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    res = gpt_lookup_completion(["A"], ["B", "C"])
+    assert res == {"A": "B"}
+


### PR DESCRIPTION
## Summary
- introduce `gpt_lookup_completion` to query OpenAI for lookup suggestions
- lazily configure OpenAI client in `mapping_utils`
- add "Auto-map Unmapped" button in lookup step to fill missing values
- unit test for GPT lookup completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883e51cd5ec83339530611a59c18f3a