### PR TITLE
Enable adding custom header fields

### DIFF
--- a/app_utils/mapping/exporter.py
+++ b/app_utils/mapping/exporter.py
@@ -11,6 +11,13 @@ from .computed_layer import persist_expression_from_state
 def _apply_header_expressions(layer: Dict[str, Any], idx: int, state: MutableMapping[str, Any]) -> Dict[str, Any]:
     new_layer = deepcopy(layer)
     mapping = state.get(f"header_mapping_{idx}", {})
+
+    # include any extra fields added by the user
+    extras = state.get(f"header_extra_fields_{idx}", [])
+    for name in extras:
+        if not any(f.get("key") == name for f in new_layer.get("fields", [])):
+            new_layer.setdefault("fields", []).append({"key": name, "required": False})
+
     for field in new_layer.get("fields", []):
         info = mapping.get(field["key"], {})
         if "src" in info:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -30,3 +30,15 @@ def test_expressions_in_output():
 
     computed_layer = out["layers"][2]
     assert computed_layer["formula"]["expression"] == "df['A'] - df['B']"
+
+
+def test_extra_fields_preserved():
+    template = load_sample("standard-fm-coa")
+    state = {
+        "header_mapping_0": {"NEW_COL": {"src": "A"}},
+        "header_extra_fields_0": ["NEW_COL"],
+    }
+    out = build_output_template(template, state)
+    header_layer = out["layers"][0]
+    added = next(f for f in header_layer["fields"] if f["key"] == "NEW_COL")
+    assert added["source"] == "A"


### PR DESCRIPTION
## Summary
- allow users to append extra fields in header step
- include extra fields in exported templates
- test that exporter preserves these fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883f93310fc8333aeccab6809179317