### PR TITLE
Add CLI for template mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ OPENAI_API_KEY = "your-openai-key"
 ```
 
 Streamlit will automatically load this file when running the app.
+
+## Command Line Interface
+
+Run the mapping pipeline directly from the terminal using `cli.py`:
+
+```bash
+python cli.py <template.json> <input.csv|xlsx> <output.json>
+```
+
+The script loads the template, auto-maps columns using heuristics, and writes a
+new template JSON with those mappings and any resolved formulas.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+from schemas.template_v2 import Template
+from app_utils.excel_utils import excel_to_json
+from app_utils.mapping_utils import suggest_header_mapping
+from app_utils.mapping.computed_layer import resolve_computed_layer
+from app_utils.mapping.exporter import build_output_template
+
+
+def load_template(path: Path) -> Template:
+    with path.open() as f:
+        data = json.load(f)
+    return Template.model_validate(data)
+
+
+def load_data(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() in {".xls", ".xlsx", ".xlsm"}:
+        records, _ = excel_to_json(str(path))
+        return pd.DataFrame(records)
+    return pd.read_csv(path)
+
+
+def auto_map(template: Template, df: pd.DataFrame) -> Dict[str, Any]:
+    state: Dict[str, Any] = {}
+    columns = list(df.columns)
+    for idx, layer in enumerate(template.layers):
+        if layer.type == "header":
+            fields = [f.key for f in layer.fields]  # type: ignore[attr-defined]
+            state[f"header_mapping_{idx}"] = suggest_header_mapping(fields, columns)
+        elif layer.type == "computed":
+            result = resolve_computed_layer(layer.model_dump(), df)
+            state[f"computed_result_{idx}"] = result
+    return state
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Map data to template")
+    parser.add_argument("template", type=Path, help="Path to template JSON")
+    parser.add_argument("input_file", type=Path, help="Path to CSV/Excel source")
+    parser.add_argument("output", type=Path, help="Destination for mapped JSON")
+    args = parser.parse_args()
+
+    template = load_template(args.template)
+    df = load_data(args.input_file)
+    state = auto_map(template, df)
+    mapped = build_output_template(template, state)
+
+    with args.output.open("w") as f:
+        json.dump(mapped, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/simple-template.json
+++ b/tests/fixtures/simple-template.json
@@ -1,0 +1,12 @@
+{
+  "template_name": "simple-template",
+  "layers": [
+    {
+      "type": "header",
+      "fields": [
+        {"key": "Name", "required": true},
+        {"key": "Value", "required": true}
+      ]
+    }
+  ]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_cli_basic(tmp_path: Path):
+    tpl = Path('tests/fixtures/simple-template.json')
+    src = Path('tests/fixtures/simple.csv')
+    out = tmp_path / 'out.json'
+
+    subprocess.check_call(['python', 'cli.py', str(tpl), str(src), str(out)])
+
+    data = json.loads(out.read_text())
+    header_layer = data['layers'][0]
+    fields = {f['key']: f.get('source') for f in header_layer['fields']}
+    assert fields['Name'] == 'Name'
+    assert fields['Value'] == 'Value'
+


### PR DESCRIPTION
## Summary
- add `cli.py` with argparse interface
- document CLI usage
- provide template fixture for tests
- add tests to verify CLI output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883fdb649888333b15fe3ab838dbf5e