### PR TITLE
Move add field control

### DIFF
--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -72,20 +72,6 @@ def render(layer, idx: int) -> None:
                     "expr_display": s["display"],
                 }
 
-    # Add new field prompt
-    if st.button("+ Add field", key=f"add_field_btn_{idx}"):
-        st.session_state[f"adding_field_{idx}"] = True
-
-    if st.session_state.get(f"adding_field_{idx}"):
-        with st.form(f"add_field_form_{idx}", clear_on_submit=True):
-            new_name = st.text_input("New column name", key=f"new_field_{idx}")
-            submitted = st.form_submit_button("Add")
-        if submitted and new_name:
-            extra_fields.append(new_name)
-            mapping[new_name] = {}
-            st.session_state[extra_key] = extra_fields
-            st.session_state[f"adding_field_{idx}"] = False
-            st.rerun()
 
     st.caption("• ✅ mapped  • 🛈 suggested  • ❌ required & missing")
 
@@ -162,6 +148,22 @@ def render(layer, idx: int) -> None:
         row[4].markdown(status)
 
     st.session_state[map_key] = mapping  # persist any edits
+
+    # Add field row (appears below mapping table)
+    add_row = st.columns([3, 1, 4, 3, 1])
+    if st.session_state.get(f"adding_field_{idx}"):
+        with add_row[3].form(f"add_field_form_{idx}", clear_on_submit=True):
+            new_name = st.text_input("New column name", key=f"new_field_{idx}")
+            submitted = st.form_submit_button("Add")
+        if submitted and new_name:
+            extra_fields.append(new_name)
+            mapping[new_name] = {}
+            st.session_state[extra_key] = extra_fields
+            st.session_state[f"adding_field_{idx}"] = False
+            st.rerun()
+    else:
+        if add_row[3].button("+ Add field", key=f"add_field_btn_{idx}"):
+            st.session_state[f"adding_field_{idx}"] = True
 
     # 5⃣  Confirm button
     ready = all(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -42,3 +42,15 @@ def test_extra_fields_preserved():
     header_layer = out["layers"][0]
     added = next(f for f in header_layer["fields"] if f["key"] == "NEW_COL")
     assert added["source"] == "A"
+
+
+def test_extra_field_expression():
+    template = load_sample("standard-fm-coa")
+    state = {
+        "header_mapping_0": {"ADDED": {"expr": "df['A']*2"}},
+        "header_extra_fields_0": ["ADDED"],
+    }
+    out = build_output_template(template, state)
+    header_layer = out["layers"][0]
+    added = next(f for f in header_layer["fields"] if f["key"] == "ADDED")
+    assert added["expression"] == "df['A']*2"


### PR DESCRIPTION
## Summary
- shift the header mapping `+ Add field` UI to a new row
- update exporter tests for extra field expression handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688402028bcc83338cf5b118fea1f7a8