### PR TITLE
Fix Add field button bug

### DIFF
--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -188,6 +188,7 @@ def render(layer, idx: int) -> None:
     else:
         if add_row[3].button("+ Add field", key=f"add_field_btn_{idx}"):
             st.session_state[f"adding_field_{idx}"] = True
+            st.rerun()
 
     # 5⃣  Confirm button
     ready = all(


### PR DESCRIPTION
## Summary
- rerun Streamlit page after starting Add field so the form appears instantly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68840d7853388333a8a0bfc28787ec46