### PR TITLE
Streamlined template uploader with safety checks

### DIFF
--- a/app_utils/template_builder.py
+++ b/app_utils/template_builder.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 """Helpers for building minimal template JSON files."""
 
 from typing import Dict, List
+import json
+import os
+from schemas.template_v2 import Template
 
 
 def build_header_template(
@@ -21,3 +24,21 @@ def build_header_template(
             }
         ],
     }
+
+
+def load_template_json(uploaded) -> Dict:
+    """Load and validate a template JSON uploaded file."""
+    data = json.load(uploaded)
+    Template.model_validate(data)
+    return data
+
+
+def save_template_file(tpl: Dict, directory: str = "templates") -> str:
+    """Save validated template to templates/<name>.json and return name."""
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in tpl["template_name"])
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, f"{safe}.json")
+    with open(path, "w") as f:
+        json.dump(tpl, f, indent=2)
+    return safe
+

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,8 +1,8 @@
-import io
 
 from schemas.template_v2 import Template
 from app_utils.excel_utils import read_tabular_file
 from app_utils.template_builder import build_header_template
+from app_utils.template_builder import load_template_json, save_template_file
 
 
 def test_scan_csv_columns():
@@ -17,3 +17,16 @@ def test_build_header_template_valid():
     required = {"A": True, "B": False}
     tpl = build_header_template("demo", cols, required)
     Template.model_validate(tpl)
+
+
+def test_load_template_json_valid():
+    with open('tests/fixtures/simple-template.json') as f:
+        tpl = load_template_json(f)
+    assert tpl['template_name'] == 'simple-template'
+
+
+def test_save_template_file(tmp_path):
+    tpl = {"template_name": "demo*temp", "layers": []}
+    name = save_template_file(tpl, directory=tmp_path)
+    assert (tmp_path / f"{name}.json").exists()
+


### PR DESCRIPTION
## Summary
- unify template upload for JSON and CSV/Excel
- add helper functions to load and save templates
- prompt confirmation before deleting a template
- fix edit dialog so it actually displays
- test new template helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6884142b37e083339100b923d2d0ccc4