### PR TITLE
Fix windows temp file delete issue

### DIFF
--- a/app_utils/excel_utils.py
+++ b/app_utils/excel_utils.py
@@ -100,10 +100,15 @@ def list_sheets(uploaded_file) -> List[str]:
     if uploaded_file.name.lower().endswith((".xls", ".xlsx", ".xlsm")):
         import os
         tmp_path = _copy_to_temp(uploaded_file, ".xlsx")
+        wb = load_workbook(tmp_path, read_only=True, keep_vba=True)
         try:
-            wb = load_workbook(tmp_path, read_only=True, keep_vba=True)
-            return [ws.title for ws in wb.worksheets if ws.sheet_state == "visible"]
+            return [
+                ws.title
+                for ws in wb.worksheets
+                if ws.sheet_state == "visible"
+            ]
         finally:
+            wb.close()
             os.unlink(tmp_path)
     return ["Sheet1"]
 

--- a/tests/test_excel_utils.py
+++ b/tests/test_excel_utils.py
@@ -42,17 +42,18 @@ def test_list_sheets_closes_temp(monkeypatch, tmp_path):
         def __init__(self, *_args, **_kwargs):
             pass
 
-        def __enter__(self):
-            return self
+        @property
+        def worksheets(self):
+            class DummySheet:
+                title = "First"
+                sheet_state = "visible"
 
-        def __exit__(self, exc_type, exc, tb):
+            return [DummySheet()]
+
+        def close(self):
             closed["val"] = True
 
-        @property
-        def sheet_names(self):
-            return ["First"]
-
-    monkeypatch.setattr(excel_utils.pd, "ExcelFile", DummyExcelFile)
+    monkeypatch.setattr(excel_utils, "load_workbook", lambda *_args, **_kwargs: DummyExcelFile())
 
     import os
 


### PR DESCRIPTION
## Summary
- ensure Excel workbook handles are closed before deleting temp files
- update tests to mock `load_workbook`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887be175c54833382e4ad5e5d1c42c3