### PR TITLE
Fix template name field visibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,6 +86,7 @@
 | D-4 | 🔨 Dedicated Template Builder page  | Codex  | Step-by-step wizard creates header layer. |
 | D-5 | 🔨 GPT-assisted field suggestions   | Codex  | Builder proposes required fields.         |
 | D-6 | 🔨 Support lookup & computed layers | Codex  | Builder adds lookup dictionaries and formulas. |
+| D-6.1 | 🗓 Multi-layer builder | Codex  | Builder allows adding sub-layers like `standard-fm-coa.json`. |
 
 ### Phase E – Docs, packaging & CI (**complete**)
 

--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -40,7 +40,7 @@ def show() -> None:
     # Create new template from sample file
     # ------------------------------------------------------------------
     st.header("Create New Template")
-    name = st.text_input("Template Name", key="tm_name")
+
     uploaded = st.file_uploader(
         "Upload CSV/Excel sample or Template JSON",
         type=["csv", "xls", "xlsx", "xlsm", "json"],
@@ -58,6 +58,7 @@ def show() -> None:
             except Exception as e:  # noqa: BLE001
                 st.error(f"Failed to read JSON: {e}")
         else:
+            st.text_input("Template Name", key="tm_name")
             sheets = list_sheets(uploaded)
             sheet_key = "tm_sheet"
             if len(sheets) > 1:
@@ -90,6 +91,8 @@ def show() -> None:
         st.session_state["tm_required"] = {
             c: selections.get(c) == "required" for c in columns if selections.get(c) != "omit"
         }
+
+    name = st.session_state.get("tm_name", "")
 
     if st.button("Save Template", disabled=not (name and columns)):
         selected_cols, req_map = apply_field_choices(columns, selections)

--- a/tests/test_template_manager_ui.py
+++ b/tests/test_template_manager_ui.py
@@ -1,0 +1,116 @@
+import types
+import importlib
+import sys
+
+class DummySidebar:
+    def __init__(self) -> None:
+        self.seen = []
+
+    def subheader(self, _txt: str) -> None:
+        pass
+
+    def write(self, txt: str) -> None:
+        self.seen.append(txt)
+
+    def info(self, _txt: str) -> None:
+        pass
+
+class DummyContainer:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        pass
+
+    def markdown(self, *a, **k) -> None:
+        pass
+
+    def progress(self, *a, **k) -> None:
+        pass
+
+class DummyStreamlit:
+    def __init__(self, uploaded=None) -> None:
+        self.session_state = {}
+        self.sidebar = DummySidebar()
+        self._uploaded = uploaded
+        self.text_input_calls = 0
+
+    def title(self, *a, **k) -> None:
+        pass
+
+    header = title
+    subheader = title
+    success = title
+    error = title
+    write = title
+    warning = title
+    info = title
+
+    def text_input(self, *a, **k):
+        self.text_input_calls += 1
+        return ""
+
+    def file_uploader(self, *a, **k):
+        return self._uploaded
+
+    def checkbox(self, *a, **k):
+        return False
+
+    def button(self, *a, **k):
+        return False
+
+    def columns(self, spec):
+        return [types.SimpleNamespace(button=self.button, write=self.write) for _ in spec]
+
+    def empty(self) -> DummyContainer:
+        return DummyContainer()
+
+    def divider(self) -> None:
+        pass
+
+    def dialog(self, *a, **k):
+        def wrap(func):
+            return func
+        return wrap
+
+    def rerun(self) -> None:
+        pass
+
+    def markdown(self, *a, **k) -> None:
+        pass
+
+    def cache_data(self, *a, **k):
+        def wrap(func):
+            return func
+        return wrap
+
+
+def run_manager(monkeypatch, uploaded=None):
+    dummy_st = DummyStreamlit(uploaded)
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_st)
+    monkeypatch.setitem(
+        sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None)
+    )
+    monkeypatch.setenv("DISABLE_AUTH", "1")
+    monkeypatch.setattr(
+        "app_utils.excel_utils.list_sheets", lambda _uploaded: ["Sheet1"]
+    )
+    monkeypatch.setattr(
+        "app_utils.excel_utils.read_tabular_file",
+        lambda _uploaded, sheet_name=None: ([], []),
+    )
+    sys.modules.pop("pages.template_manager", None)
+    importlib.import_module("pages.template_manager")
+    return dummy_st
+
+
+def test_no_name_field_before_upload(monkeypatch):
+    dummy = run_manager(monkeypatch, uploaded=None)
+    assert dummy.text_input_calls == 0
+
+
+def test_name_field_after_upload(monkeypatch):
+    dummy_file = types.SimpleNamespace(name="demo.csv")
+    dummy = run_manager(monkeypatch, uploaded=dummy_file)
+    assert dummy.text_input_calls == 1
+


### PR DESCRIPTION
## Summary
- only show Template Name input after uploading a sample file
- place Template Name below file upload and above sheet selection
- add roadmap entry for multi-layer builder
- unit tests for template manager UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6887c45abab08333a82d18cf93e437ae