### PR TITLE
Add postprocess spec to template schema

### DIFF
--- a/schemas/template_v2.py
+++ b/schemas/template_v2.py
@@ -65,12 +65,23 @@ class ComputedLayer(BaseModel):
     formula: ComputedFormula
 
 
+class PostprocessSpec(BaseModel):
+    """Optional post-processing instructions."""
+
+    type: str
+    connection: Optional[str] = None
+    table: Optional[str] = None
+    column_map: Optional[Dict[str, str]] = None
+    script: Optional[str] = None
+
+
 Layer = HeaderLayer | LookupLayer | ComputedLayer
 
 
 class Template(BaseModel):
     template_name: str
     layers: List[Layer]
+    postprocess: Optional[PostprocessSpec] = None
 
     # Allow unknown top-level keys (back-compat)
     model_config = ConfigDict(extra="allow")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import pytest
 from schemas.template_v2 import Template, ValidationError
 
 
@@ -23,6 +24,32 @@ def test_pit_header_only_valid():
         ],
     }
     Template.model_validate(pit)
+
+
+def test_postprocess_valid():
+    tpl = {
+        "template_name": "demo",
+        "layers": [
+            {"type": "header", "fields": [{"key": "A"}]}
+        ],
+        "postprocess": {
+            "type": "sql_insert",
+            "connection": "mssql://example",
+            "table": "dbo.OUT",
+            "column_map": {"A": "A"},
+        },
+    }
+    Template.model_validate(tpl)
+
+
+def test_postprocess_missing_type_fails():
+    tpl = {
+        "template_name": "demo",
+        "layers": [{"type": "header", "fields": [{"key": "A"}]}],
+        "postprocess": {"table": "dbo.OUT"},
+    }
+    with pytest.raises(ValidationError):
+        Template.model_validate(tpl)
 
 
 def test_missing_layers_fails():


### PR DESCRIPTION
## Summary
- support optional postprocess block in template schema
- validate postprocess in Template model
- test validator accepts valid postprocess and rejects malformed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887cfd2038483338f8e610390ebef15