### PR TITLE
Add postprocess editing in template manager

### DIFF
--- a/app_utils/template_builder.py
+++ b/app_utils/template_builder.py
@@ -9,13 +9,16 @@ from schemas.template_v2 import Template
 
 
 def build_header_template(
-    template_name: str, columns: List[str], required: Dict[str, bool]
+    template_name: str,
+    columns: List[str],
+    required: Dict[str, bool],
+    postprocess: Dict | None = None,
 ) -> Dict:
     """Return a basic header-only template structure."""
     fields = [
         {"key": col, "required": bool(required.get(col, False))} for col in columns
     ]
-    return {
+    tpl = {
         "template_name": template_name,
         "layers": [
             {
@@ -24,6 +27,9 @@ def build_header_template(
             }
         ],
     }
+    if postprocess:
+        tpl["postprocess"] = postprocess
+    return tpl
 
 
 def load_template_json(uploaded) -> Dict:

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -18,7 +18,16 @@ def test_scan_csv_columns():
 def test_build_header_template_valid():
     cols = ["A", "B"]
     required = {"A": True, "B": False}
-    tpl = build_header_template("demo", cols, required)
+    tpl = build_header_template("demo", cols, required, None)
+    Template.model_validate(tpl)
+
+
+def test_build_header_template_with_postprocess():
+    cols = ["A"]
+    required = {"A": True}
+    post = {"type": "sql_insert"}
+    tpl = build_header_template("demo", cols, required, post)
+    assert tpl["postprocess"] == post
     Template.model_validate(tpl)
 
 
@@ -93,6 +102,9 @@ def test_render_sidebar_columns(monkeypatch):
 
         def button(self, *a, **k):
             return False
+
+        def text_area(self, label, key=None, **k):
+            return ""
 
         def columns(self, spec):
             return [


### PR DESCRIPTION
## Summary
- support optional postprocess config in `build_header_template`
- surface a "Postprocess JSON" field when creating a template
- allow editing postprocess separately in `edit_template`
- update template builder and manager unit tests
- extend template manager UI tests for new field and behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887d18ef0808333a545fb9352eb1bb1