### PR TITLE
Update docs for postprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ python cli.py <template.json> <input.csv|xlsx> <output.json>
 
 The script loads the template, auto-maps columns using heuristics, and writes a
 new template JSON with those mappings and any resolved formulas.
+
+## Post-processing
+
+Templates may include an optional `postprocess` block. When present, the
+specified action runs automatically once mapping completes. See
+`docs/template_spec.md` for supported types.

--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -149,7 +149,6 @@ At run-time the user builds an expression; the engine stores its resolution:
 
 ### 3.4  `postprocess` (optional, top-level)
 
-
 ```jsonc
 "postprocess": {
   "type": "sql_insert",
@@ -157,7 +156,16 @@ At run-time the user builds an expression; the engine stores its resolution:
   "table": "dbo.MAPPED_OUTPUT",
   "column_map": { "GL_ID": "GL_ID", "NET_CHANGE": "NET_CHANGE" }
 }
+```
 
+Supported **`type`** values:
+
+| Type            | Purpose                                   |
+|-----------------|--------------------------------------------|
+| `excel_template`| Fill an Excel workbook using mapped data.  |
+| `sql_insert`    | Insert rows into a SQL table via ODBC.     |
+| `http_request`  | Send mapped data as an HTTP request body.  |
+| `python_script` | Execute inline Python code with `df` bound.|
 
 ---
 


### PR DESCRIPTION
## Summary
- document available `postprocess` types in the template spec
- mention postprocessing in the project README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887d43f45b4833398cde950d8dcb7d6