### PR TITLE
Improve template builder postprocess UI

### DIFF
--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -92,7 +92,13 @@ def show() -> None:
             c: selections.get(c) == "required" for c in columns if selections.get(c) != "omit"
         }
 
-    st.text_area("Postprocess JSON (optional)", key="tm_postprocess", height=200)
+    if columns:
+        st.text_area(
+            "Postprocess JSON (optional)",
+            key="tm_postprocess",
+            height=200,
+            placeholder='{"strip": true}  # Example post-processing rules',
+        )
 
     name = st.session_state.get("tm_name", "")
 

--- a/tests/test_template_manager_ui.py
+++ b/tests/test_template_manager_ui.py
@@ -64,6 +64,9 @@ class DummyStreamlit:
         self.text_area_labels.append(label)
         return self.session_state.get(key, "")
 
+    def radio(self, label, options, index=0, **k):
+        return options[index]
+
     def columns(self, spec):
         return [types.SimpleNamespace(button=self.button, write=self.write) for _ in spec]
 
@@ -137,8 +140,14 @@ def test_name_field_after_upload(monkeypatch):
 
 def test_postprocess_field_shown(monkeypatch):
     dummy_file = types.SimpleNamespace(name="demo.csv")
-    dummy = run_manager(monkeypatch, uploaded=dummy_file)
+    dummy = run_manager(monkeypatch, uploaded=dummy_file, cols=["A"]) 
     assert "Postprocess JSON (optional)" in dummy.text_area_labels
+
+
+def test_postprocess_field_hidden_without_columns(monkeypatch):
+    dummy_file = types.SimpleNamespace(name="demo.csv")
+    dummy = run_manager(monkeypatch, uploaded=dummy_file, cols=[])
+    assert "Postprocess JSON (optional)" not in dummy.text_area_labels
 
 
 def test_postprocess_passed_to_builder(monkeypatch):


### PR DESCRIPTION
## Summary
- hide the postprocess text area until a template file is uploaded and columns are detected
- add example placeholder text that disappears when typing
- update UI tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887d818f24483339a160ba8797e1219