### PR TITLE
Improve postprocess instructions

### DIFF
--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -93,11 +93,14 @@ def show() -> None:
         }
 
     if columns:
+        st.caption(
+            "Optional instructions to run after mapping. See `docs/template_spec.md#3.4` for supported actions."
+        )
         st.text_area(
             "Postprocess JSON (optional)",
             key="tm_postprocess",
             height=200,
-            placeholder='{"strip": true}  # Example post-processing rules',
+            placeholder='{"type": "sql_insert", "table": "dbo.OUT"}',
         )
 
     name = st.session_state.get("tm_name", "")
@@ -162,6 +165,9 @@ def edit_template(filename: str, data: dict) -> None:
     @st.dialog(f"Edit Template '{filename}'", width="large")
     def _dlg() -> None:
         st.text_area("Template JSON", key, height=400)
+        st.caption(
+            "Optional instructions to run after mapping. See `docs/template_spec.md#3.4` for details."
+        )
         st.text_area("Postprocess JSON (optional)", post_key, height=200)
         c1, c2 = st.columns(2)
         if c1.button("Save", key=f"{key}_save"):

--- a/tests/test_template_manager_ui.py
+++ b/tests/test_template_manager_ui.py
@@ -35,6 +35,7 @@ class DummyStreamlit:
         self._uploaded = uploaded
         self.text_input_calls = 0
         self.text_area_labels: list[str] = []
+        self.captions: list[str] = []
 
     def title(self, *a, **k) -> None:
         pass
@@ -46,6 +47,7 @@ class DummyStreamlit:
     write = title
     warning = title
     info = title
+    caption = lambda self, txt, **k: self.captions.append(txt)
 
     def text_input(self, *a, **k):
         self.text_input_calls += 1
@@ -168,4 +170,10 @@ def test_postprocess_passed_to_builder(monkeypatch):
     )
 
     assert captured["post"] == {"type": "sql_insert"}
+
+
+def test_postprocess_caption_displayed(monkeypatch):
+    dummy_file = types.SimpleNamespace(name="demo.csv")
+    dummy = run_manager(monkeypatch, uploaded=dummy_file, cols=["A"])
+    assert any("docs/template_spec.md" in c for c in dummy.captions)
 


### PR DESCRIPTION
## Summary
- show instructions for the Postprocess JSON text area when creating or editing templates
- track captions in the UI tests and validate instruction display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887d9cf60148333b96be8173b872a1d