### PR TITLE
Track unsaved template changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,11 @@ def main():
     st.set_page_config(page_title="AI Mapping Agent", layout="wide")
     st.title("AI Mapping Agent")
 
+    if st.session_state.get("unsaved_changes"):
+        st.warning(
+            "You have unsaved template changes. Use the Template Manager to save them."
+        )
+
     TEMPLATES_DIR = Path("templates")
     TEMPLATES_DIR.mkdir(exist_ok=True)
 


### PR DESCRIPTION
## Summary
- mark unsaved changes when editing header mappings
- show unsaved warning banner in main app
- reset `unsaved_changes` when saving a template
- test new behaviour around unsaved flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688848268778833389295844543ae0d1