### PR TITLE
Persist unsaved flag on header field edits

### DIFF
--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -49,7 +49,8 @@ def remove_field(field_key: str, idx: int) -> None:
         layer = tpl["layers"][idx]
         layer["fields"] = [f for f in layer.get("fields", []) if f.get("key") != field_key]
         st.session_state["template"] = tpl
-        st.session_state["unsaved_changes"] = True
+
+    st.session_state["unsaved_changes"] = True
 
 
 def add_field(field_key: str, idx: int) -> None:
@@ -72,7 +73,8 @@ def add_field(field_key: str, idx: int) -> None:
         if not any(f.get("key") == field_key for f in layer.get("fields", [])):
             layer.setdefault("fields", []).append({"key": field_key, "required": False})
         st.session_state["template"] = tpl
-        st.session_state["unsaved_changes"] = True
+
+    st.session_state["unsaved_changes"] = True
 
 # ─── CSS tweaks ───────────────────────────────────────────────────────
 st.markdown(

--- a/tests/test_header_mapping.py
+++ b/tests/test_header_mapping.py
@@ -106,6 +106,17 @@ def test_add_field_sets_unsaved(monkeypatch):
     assert "Extra" in st.session_state[f"header_extra_fields_{idx}"]
 
 
+def test_add_remove_field_without_template():
+    idx = 0
+    st.session_state.clear()
+    add_field("Extra", idx)
+    assert st.session_state["unsaved_changes"] is True
+    assert "template" not in st.session_state
+    st.session_state["unsaved_changes"] = False
+    remove_field("Extra", idx)
+    assert st.session_state["unsaved_changes"] is True
+
+
 def test_set_field_mapping_marks_unsaved():
     idx = 0
     key = f"header_mapping_{idx}"


### PR DESCRIPTION
## Summary
- flag `unsaved_changes` whenever header fields are added or removed
- persist updates to the in-memory template
- test flag behaviour with and without a loaded template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888d79229248333b4bfdb4892cc6d3e