### PR TITLE
Support user_defined computed strategy

### DIFF
--- a/app_utils/mapping/computed_layer.py
+++ b/app_utils/mapping/computed_layer.py
@@ -54,8 +54,35 @@ def resolve_computed_layer(layer: Dict[str, Any], df: pd.DataFrame) -> Dict[str,
     formula = layer["formula"]
     strategy = formula.get("strategy", "first_available")
 
+    if strategy == "always":
+        expr = formula.get("expression")
+        if not expr:
+            raise ValueError("'expression' required when strategy='always'")
+        return {
+            "resolved": True,
+            "method": "derived",
+            "source_cols": [],
+            "expression": expr,
+        }
+
+    if strategy == "user_defined":
+        expr = formula.get("expression")
+        if expr:
+            return {
+                "resolved": True,
+                "method": "derived",
+                "source_cols": [],
+                "expression": expr,
+            }
+        return {
+            "resolved": False,
+            "method": None,
+            "source_cols": [],
+            "expression": None,
+        }
+
     if strategy != "first_available":
-        raise NotImplementedError("Only first_available strategy supported")
+        raise NotImplementedError("Unsupported strategy")
 
     for cand in formula["candidates"]:
         if cand["type"] == "direct":

--- a/app_utils/template_builder.py
+++ b/app_utils/template_builder.py
@@ -112,16 +112,22 @@ def build_lookup_layer(
 
 
 def build_computed_layer(
-    target_field: str, expression: str, sheet: str | None = None
+    target_field: str, expression: str | None = None, sheet: str | None = None
 ) -> Dict:
-    """Return a validated computed layer with a user-defined expression."""
+    """Return a validated computed layer.
+
+    If ``expression`` is provided the layer uses ``strategy='always'``.
+    Otherwise it will be ``strategy='user_defined'`` and the user is expected
+    to supply an expression at run-time.
+    """
+
+    formula = {"strategy": "always", "expression": expression} if expression else {
+        "strategy": "user_defined"
+    }
     layer = {
         "type": "computed",
         "target_field": target_field,
-        "formula": {
-            "strategy": "always",
-            "expression": expression,
-        },
+        "formula": formula,
     }
     if sheet:
         layer["sheet"] = sheet

--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -126,7 +126,8 @@ Supported **`strategy`** values:
 
 ---
 
-If `strategy` =`"user_defined"` the `candidates` array **may be omitted**.
+If `strategy` =`"user_defined"` the `candidates` array **may be omitted** and
+`expression` is typically left blank.
 At run-time the user builds an expression; the engine stores its resolution:
 
 ```jsonc

--- a/pages/steps/computed.py
+++ b/pages/steps/computed.py
@@ -20,19 +20,24 @@ def render(layer, idx: int):
             st.session_state["uploaded_file"], sheet_name=sheet_name
         )
 
+    strategy = getattr(layer, "formula", {}).get("strategy", "first_available")
+
     # 1. Decide Direct vs Computed
     mode_key = f"computed_mode_{idx}"
-    mode = st.radio(
-        "How should this field be populated?",
-        options=["Direct (one column)", "Computed (expression)"],
-        key=mode_key,
-    )
+    if strategy == "user_defined":
+        mode = "Computed (expression)"
+    else:
+        mode = st.radio(
+            "How should this field be populated?",
+            options=["Direct (one column)", "Computed (expression)"],
+            key=mode_key,
+        )
 
     result_key = f"computed_result_{idx}"
     result = st.session_state.get(result_key, {"resolved": False})
 
     # 2A. Direct mapping UI
-    if mode.startswith("Direct"):
+    if mode.startswith("Direct") and strategy != "user_defined":
         col = st.selectbox(
             "Select source column",
             options=[""] + list(df.columns),

--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -283,10 +283,10 @@ def render(layer, idx: int) -> None:
 
     with st.expander("Computed Layer"):
         ctgt = st.text_input("Target field", key=f"comp_tgt_{idx}")
-        cexpr = st.text_input("Expression", key=f"comp_expr_{idx}")
+        cexpr = st.text_input("Expression (optional)", key=f"comp_expr_{idx}")
         csheet = st.text_input("Sheet (optional)", key=f"comp_sheet_{idx}")
-        if st.button("Add Computed Layer", key=f"add_comp_{idx}") and ctgt and cexpr:
-            append_computed_layer(ctgt, cexpr, csheet or None)
+        if st.button("Add Computed Layer", key=f"add_comp_{idx}") and ctgt:
+            append_computed_layer(ctgt, cexpr or None, csheet or None)
             st.rerun()
 
     if st.button("Save Template", key=f"save_template_{idx}"):

--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -162,13 +162,13 @@ def show() -> None:
         st.subheader("Add Computed Layer")
         ccol1, ccol2 = st.columns([1, 1])
         ctgt = ccol1.text_input("Computed target", key="tm_comp_tgt")
-        expr = ccol1.text_input("Expression", key="tm_comp_expr")
+        expr = ccol1.text_input("Expression (optional)", key="tm_comp_expr")
         csheet = ccol2.text_input(
             "Sheet (optional)", key="tm_comp_sheet", placeholder="Sheet1"
         )
-        if st.button("Add Computed Layer") and ctgt and expr:
+        if st.button("Add Computed Layer") and ctgt:
             extra_layers.append(
-                build_computed_layer(ctgt, expr, sheet=csheet or None)
+                build_computed_layer(ctgt, expr or None, sheet=csheet or None)
             )
             st.session_state["tm_comp_tgt"] = ""
             st.session_state["tm_comp_expr"] = ""

--- a/schemas/template_v2.py
+++ b/schemas/template_v2.py
@@ -51,8 +51,8 @@ class LookupLayer(BaseModel):
 
 
 class ComputedFormula(BaseModel):
-    # strategy: first_available | always
-    strategy: Literal["first_available", "always"] = "first_available"
+    # strategy: first_available | user_defined | always
+    strategy: Literal["first_available", "user_defined", "always"] = "first_available"
     candidates: Optional[List[Dict[str, Any]]] = None
     expression: Optional[str] = None
     dependencies: Optional[Dict[str, List[str]]] = None

--- a/templates/user-defined-demo.json
+++ b/templates/user-defined-demo.json
@@ -1,0 +1,16 @@
+{
+  "template_name": "User Defined Demo",
+  "layers": [
+    {
+      "type": "header",
+      "fields": [
+        {"key": "A", "required": true}
+      ]
+    },
+    {
+      "type": "computed",
+      "target_field": "TOTAL",
+      "formula": {"strategy": "user_defined"}
+    }
+  ]
+}

--- a/tests/test_computed_layer.py
+++ b/tests/test_computed_layer.py
@@ -2,7 +2,10 @@ import json
 
 import pandas as pd
 
-from app_utils.mapping.computed_layer import gpt_formula_suggestion
+from app_utils.mapping.computed_layer import (
+    gpt_formula_suggestion,
+    resolve_computed_layer,
+)
 
 
 def test_gpt_formula_suggestion(monkeypatch):
@@ -29,3 +32,14 @@ def test_gpt_formula_suggestion(monkeypatch):
     df = pd.DataFrame({"A": [1], "B": [2]})
     expr = gpt_formula_suggestion("NET_CHANGE", df)
     assert expr == "df['A'] + df['B']"
+
+
+def test_resolve_user_defined_unresolved():
+    layer = {
+        "type": "computed",
+        "target_field": "TOTAL",
+        "formula": {"strategy": "user_defined"},
+    }
+    df = pd.DataFrame({"A": [1]})
+    result = resolve_computed_layer(layer, df)
+    assert result["resolved"] is False

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -242,3 +242,11 @@ def test_build_template_multiple_extra_layers():
     layers = [header["layers"][0], l1, l2, c1]
     tpl = build_template("demo", layers)
     Template.model_validate(tpl)
+
+
+def test_user_defined_computed_layer():
+    """Builder should create placeholder with user_defined strategy."""
+    layer = build_computed_layer("TOTAL")
+    assert layer["formula"]["strategy"] == "user_defined"
+    assert "expression" not in layer["formula"]
+    Template.model_validate({"template_name": "demo", "layers": [layer]})


### PR DESCRIPTION
## Summary
- allow `user_defined` strategy in template schema
- implement `user_defined` and `always` logic in computed layer resolution
- update template builder to create placeholders when no expression supplied
- adapt UI to accept optional expressions for computed layers
- document that `expression` can be omitted for `user_defined` formulas
- provide example template demonstrating a user-defined computed field
- add tests for new functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888e93a16808333b00727d8123cfdd6