### PR TITLE
Add second header layer to template

### DIFF
--- a/templates/standard-fm-coa.json
+++ b/templates/standard-fm-coa.json
@@ -18,6 +18,15 @@
         { "key": "NET_CHANGE",   "required": false }
       ]
     },
+    {
+      "type": "header",
+      "fields": [
+        { "key": "GL_ID" },
+        { "key": "DETAIL_LEVEL" },
+        { "key": "GL_NAME" },
+        { "key": "NET_CHANGE" }
+      ]
+    },
 
     {
       "type": "lookup",

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -16,7 +16,7 @@ def test_expressions_in_output():
         "header_mapping_0": {
             "NET_CHANGE": {"expr": "df['A'] + df['B']"}
         },
-        "computed_result_2": {
+        "computed_result_3": {
             "resolved": True,
             "method": "derived",
             "source_cols": ["A", "B"],
@@ -28,7 +28,7 @@ def test_expressions_in_output():
     net_change = next(f for f in header_layer["fields"] if f["key"] == "NET_CHANGE")
     assert net_change["expression"] == "df['A'] + df['B']"
 
-    computed_layer = out["layers"][2]
+    computed_layer = out["layers"][3]
     assert computed_layer["formula"]["expression"] == "df['A'] - df['B']"
 
 


### PR DESCRIPTION
## Summary
- insert a second header layer into `standard-fm-coa.json`
- adjust exporter unit test to account for new layer index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888ea1c06448333addbc86069a2b8af