### PR TITLE
Fix second header layer fields

### DIFF
--- a/templates/standard-fm-coa.json
+++ b/templates/standard-fm-coa.json
@@ -23,8 +23,7 @@
       "fields": [
         { "key": "GL_ID" },
         { "key": "DETAIL_LEVEL" },
-        { "key": "GL_NAME" },
-        { "key": "NET_CHANGE" }
+        { "key": "GL_NAME" }
       ]
     },
 


### PR DESCRIPTION
## Summary
- align the second header layer in `standard-fm-coa.json` with the `accounts` object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688906da065c8333a76c3c446a2f0d1a