### PR TITLE
Simplify postprocess to one HTTP hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ new template JSON with those mappings and any resolved formulas.
 
 ## Post-processing
 
-Templates may include an optional `postprocess` block. When present, the
-specified action runs automatically once mapping completes. See
-`docs/template_spec.md` for supported types.
+Templates may include an optional `postprocess` block. When present and
+`ENABLE_POSTPROCESS=1` is set, the mapped rows are sent as a POST request to the
+configured URL. See `docs/template_spec.md` for details.

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -1,75 +1,26 @@
 from __future__ import annotations
 
-"""Dispatch optional post-process actions once mapping is done."""
+"""Minimal post-process utility."""
 
-from typing import Callable, List
+from typing import List
+import os
 import pandas as pd
 from schemas.template_v2 import PostprocessSpec, Template
-
-
-def _run_excel_template(cfg: PostprocessSpec, df: pd.DataFrame) -> None:
-    """Fill an Excel template with mapped data."""
-    try:
-        from openpyxl import load_workbook  # type: ignore
-    except Exception:
-        return
-    # Placeholder implementation
-    _ = load_workbook  # suppress unused
-    return
-
-
-def _run_sql_insert(cfg: PostprocessSpec, df: pd.DataFrame) -> None:
-    """Insert rows into a SQL table."""
-    try:
-        import pyodbc  # type: ignore
-    except Exception:
-        return
-    _ = pyodbc
-    return
-
-
-def _run_http_request(cfg: PostprocessSpec, df: pd.DataFrame) -> None:
-    """Send data via an HTTP request."""
-    try:
-        import requests  # type: ignore
-    except Exception:
-        return
-    _ = requests
-    return
-
-
-def _run_python_script(cfg: PostprocessSpec, df: pd.DataFrame) -> None:
-    """Execute inline Python code with ``df`` available."""
-    if not cfg.script:
-        return
-    local_vars = {"df": df}
-    try:
-        exec(cfg.script, {}, local_vars)
-    except Exception:
-        pass
-
-
-_DISPATCH: dict[str, Callable[[PostprocessSpec, pd.DataFrame], None]] = {
-    "excel_template": _run_excel_template,
-    "sql_insert": _run_sql_insert,
-    "http_request": _run_http_request,
-    "python_script": _run_python_script,
-}
 
 
 def run_postprocess(
     cfg: PostprocessSpec, df: pd.DataFrame, log: List[str] | None = None
 ) -> None:
-    """Execute post-processing based on ``cfg.type``."""
-    func = _DISPATCH.get(cfg.type)
-    if not func:
-        if log is not None:
-            log.append(f"Unsupported postprocess type: {cfg.type}")
-        raise ValueError(f"Unsupported postprocess type: {cfg.type}")
+    """Send mapped data to ``cfg.url`` via HTTP POST."""
     if log is not None:
-        log.append(f"Running {cfg.type}")
+        log.append(f"POST {cfg.url}")
+    if os.getenv("ENABLE_POSTPROCESS") != "1":
+        if log is not None:
+            log.append("Postprocess disabled")
+        return
     try:
-        func(cfg, df)
+        import requests  # type: ignore
+        requests.post(cfg.url, json=df.to_dict(orient="records"), timeout=10)
     except Exception as exc:  # noqa: BLE001
         if log is not None:
             log.append(f"Error: {exc}")
@@ -84,8 +35,8 @@ def run_postprocess_if_configured(
     df: pd.DataFrame,
     process_guid: str | None = None,
 ) -> List[str]:
-    """Run ``run_postprocess`` if ``template.postprocess`` is set."""
-    _ = process_guid  # currently unused but reserved for future DB hooks
+    """Run ``run_postprocess`` if ``template.postprocess`` exists."""
+    _ = process_guid  # reserved for future use
     logs: List[str] = []
     if template.postprocess:
         run_postprocess(template.postprocess, df, logs)

--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -152,26 +152,18 @@ At run-time the user builds an expression; the engine stores its resolution:
 
 ```jsonc
 "postprocess": {
-  "type": "sql_insert",
-  "connection": "Driver={ODBC Driver 18 for SQL Server};Server=tcp:demo.database.windows.net;Encrypt=yes;",
-  "table": "dbo.MAPPED_OUTPUT",
-  "column_map": { "GL_ID": "GL_ID", "NET_CHANGE": "NET_CHANGE" }
+  "url": "https://example.com/flow"
 }
 ```
 
-Supported **`type`** values:
-
-| Type            | Purpose                                   |
-|-----------------|--------------------------------------------|
-| `excel_template`| Fill an Excel workbook using mapped data.  |
-| `sql_insert`    | Insert rows into a SQL table via ODBC.     |
-| `http_request`  | Send mapped data as an HTTP request body.  |
-| `python_script` | Execute inline Python code with `df` bound.|
+When present, the mapped rows are sent as a JSON array via HTTP `POST` to the
+specified URL. Set the environment variable `ENABLE_POSTPROCESS=1` to allow
+the request during execution.
 
 After all layers are confirmed the wizard enters a **Run Export** step. If a
-`postprocess` block exists, `run_postprocess_if_configured` executes the selected
-action. A fresh `process_guid` (UUID) is stored in the final JSON together with
-any log messages from that run.
+`postprocess` block exists, `run_postprocess_if_configured` posts the mapped
+rows to the configured URL. A fresh `process_guid` (UUID) is stored in the final
+JSON together with any log messages from that run.
 
 ---
 

--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -126,13 +126,13 @@ def show() -> None:
 
     if columns:
         st.caption(
-            "Optional instructions to run after mapping. See `docs/template_spec.md#3.4` for supported actions."
+            "Optional instructions to POST mapped data after processing."
         )
         st.text_area(
             "Postprocess JSON (optional)",
             key="tm_postprocess",
             height=200,
-            placeholder='{"type": "sql_insert", "table": "dbo.OUT"}',
+            placeholder='{"url": "https://example.com/hook"}',
         )
 
         extra_layers = st.session_state.setdefault("tm_extra_layers", [])
@@ -249,7 +249,7 @@ def edit_template(filename: str, data: dict) -> None:
     def _dlg() -> None:
         st.text_area("Template JSON", key, height=400)
         st.caption(
-            "Optional instructions to run after mapping. See `docs/template_spec.md#3.4` for details."
+            "Optional instructions to POST mapped data after processing."
         )
         st.text_area("Postprocess JSON (optional)", post_key, height=200)
         c1, c2 = st.columns([1, 1])

--- a/schemas/template_v2.py
+++ b/schemas/template_v2.py
@@ -21,7 +21,8 @@ from pydantic import (
     Field,
     field_validator,
     ConfigDict,
-    ValidationError
+    ValidationError,
+    HttpUrl,
 )
 from typing import List, Literal, Optional, Dict, Any
 
@@ -66,13 +67,9 @@ class ComputedLayer(BaseModel):
 
 
 class PostprocessSpec(BaseModel):
-    """Optional post-processing instructions."""
+    """Optional POST request instructions."""
 
-    type: str
-    connection: Optional[str] = None
-    table: Optional[str] = None
-    column_map: Optional[Dict[str, str]] = None
-    script: Optional[str] = None
+    url: HttpUrl
 
 
 Layer = HeaderLayer | LookupLayer | ComputedLayer

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -1,56 +1,37 @@
+import types
+import sys
 import pandas as pd
-import pytest
-
 from schemas.template_v2 import PostprocessSpec, Template
-import app_utils.postprocess_runner as runner
 from app_utils.postprocess_runner import run_postprocess, run_postprocess_if_configured
 
 
-def test_dispatch_excel(monkeypatch):
+def test_run_postprocess_calls_requests(monkeypatch):
     called = {}
-    monkeypatch.setitem(
-        runner._DISPATCH,
-        'excel_template',
-        lambda cfg, df: called.setdefault('excel', True)
-    )
-    run_postprocess(PostprocessSpec(type='excel_template'), pd.DataFrame())
-    assert called.get('excel') is True
+
+    def fake_post(url, json=None, timeout=10):
+        called['url'] = url
+        called['json'] = json
+        return types.SimpleNamespace(status_code=200)
+
+    monkeypatch.setenv("ENABLE_POSTPROCESS", "1")
+    monkeypatch.setitem(sys.modules, "requests", types.SimpleNamespace(post=fake_post))
+    cfg = PostprocessSpec(url="https://example.com/hook")
+    run_postprocess(cfg, pd.DataFrame({"A": [1]}))
+    assert called['url'] == cfg.url
+    assert called['json'] == [{"A": 1}]
 
 
-def test_dispatch_sql(monkeypatch):
+def test_run_postprocess_disabled(monkeypatch):
+    monkeypatch.delenv("ENABLE_POSTPROCESS", raising=False)
     called = {}
-    monkeypatch.setitem(
-        runner._DISPATCH,
-        'sql_insert',
-        lambda cfg, df: called.setdefault('sql', True)
-    )
-    run_postprocess(PostprocessSpec(type='sql_insert'), pd.DataFrame())
-    assert called.get('sql') is True
-
-
-def test_dispatch_http(monkeypatch):
-    called = {}
-    monkeypatch.setitem(
-        runner._DISPATCH,
-        'http_request',
-        lambda cfg, df: called.setdefault('http', True)
-    )
-    run_postprocess(PostprocessSpec(type='http_request'), pd.DataFrame())
-    assert called.get('http') is True
-
-
-def test_dispatch_python(monkeypatch):
-    called = {}
-    monkeypatch.setitem(
-        runner._DISPATCH,
-        'python_script',
-        lambda cfg, df: called.setdefault('py', True)
-    )
-    run_postprocess(PostprocessSpec(type='python_script', script=''), pd.DataFrame())
-    assert called.get('py') is True
+    monkeypatch.setitem(sys.modules, "requests", types.SimpleNamespace(post=lambda *a, **k: called.setdefault('hit', True)))
+    cfg = PostprocessSpec(url="https://example.com/hook")
+    run_postprocess(cfg, pd.DataFrame({"A": [1]}))
+    assert 'hit' not in called
 
 
 def test_if_configured_helper(monkeypatch):
+    monkeypatch.setenv("ENABLE_POSTPROCESS", "1")
     called = {}
     monkeypatch.setattr(
         'app_utils.postprocess_runner.run_postprocess',
@@ -59,13 +40,8 @@ def test_if_configured_helper(monkeypatch):
     tpl = Template.model_validate({
         'template_name': 'demo',
         'layers': [{'type': 'header', 'fields': [{'key': 'A'}]}],
-        'postprocess': {'type': 'sql_insert'}
+        'postprocess': {'url': 'https://example.com'}
     })
     logs = run_postprocess_if_configured(tpl, pd.DataFrame())
     assert called.get('run') is True
     assert isinstance(logs, list)
-
-
-def test_unknown_type_raises():
-    with pytest.raises(ValueError):
-        run_postprocess(PostprocessSpec(type='unknown'), pd.DataFrame())

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -32,7 +32,7 @@ def test_build_header_template_valid():
 def test_build_header_template_with_postprocess():
     cols = ["A"]
     required = {"A": True}
-    post = {"type": "sql_insert"}
+    post = {"url": "https://example.com"}
     tpl = build_header_template("demo", cols, required, post)
     assert tpl["postprocess"] == post
     Template.model_validate(tpl)

--- a/tests/test_template_manager_ui.py
+++ b/tests/test_template_manager_ui.py
@@ -202,16 +202,16 @@ def test_postprocess_passed_to_builder(monkeypatch):
         uploaded=dummy_file,
         button_patch=lambda label, *a, **k: label == "Save Template",
         builder=fake_builder,
-        session_state={"tm_name": "demo", "tm_postprocess": "{\"type\": \"sql_insert\"}"},
+        session_state={"tm_name": "demo", "tm_postprocess": "{\"url\": \"https://example.com\"}"},
     )
 
-    assert captured["post"] == {"type": "sql_insert"}
+    assert captured["post"] == {"url": "https://example.com"}
 
 
 def test_postprocess_caption_displayed(monkeypatch):
     dummy_file = types.SimpleNamespace(name="demo.csv")
     dummy = run_manager(monkeypatch, uploaded=dummy_file, cols=["A"])
-    assert any("docs/template_spec.md" in c for c in dummy.captions)
+    assert any("POST mapped data" in c for c in dummy.captions)
 
 
 def test_suggest_required_fields_without_file(monkeypatch):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -32,21 +32,16 @@ def test_postprocess_valid():
         "layers": [
             {"type": "header", "fields": [{"key": "A"}]}
         ],
-        "postprocess": {
-            "type": "sql_insert",
-            "connection": "mssql://example",
-            "table": "dbo.OUT",
-            "column_map": {"A": "A"},
-        },
+        "postprocess": {"url": "https://example.com"},
     }
     Template.model_validate(tpl)
 
 
-def test_postprocess_missing_type_fails():
+def test_postprocess_missing_url_fails():
     tpl = {
         "template_name": "demo",
         "layers": [{"type": "header", "fields": [{"key": "A"}]}],
-        "postprocess": {"table": "dbo.OUT"},
+        "postprocess": {},
     }
     with pytest.raises(ValidationError):
         Template.model_validate(tpl)

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -84,7 +84,7 @@ def run_app(monkeypatch):
     )
     tpl_path = Path("templates/pit-bid.json")
     tpl_data = json.loads(tpl_path.read_text())
-    tpl_data["postprocess"] = {"type": "sql_insert"}
+    tpl_data["postprocess"] = {"url": "https://example.com"}
     orig_read = Path.read_text
     def fake_read(self, *a, **k):
         if self == tpl_path:


### PR DESCRIPTION
## Summary
- trim postprocess to a single HTTP POST action
- update schema and docs
- clean up Template Manager UI
- adjust tests to new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688908c870048333bff329bfaafdf5cd