### PR TITLE
Fix template_spec references

### DIFF
--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -207,7 +207,7 @@ mistakes raise a `ValidationError`.
 
 ### 5.2 Standard COA (header + lookup + computed)
 
-See `templates/standard-coa.json`.
+See `templates/standard-fm-coa.json`. The header is mapped once and the lookup layer fills `GL_ID` and `DETAIL_LEVEL` based on the chosen `GL_NAME`.
 
 ### 5.3 Multi-period profit (user-defined computed)
 
@@ -232,7 +232,7 @@ See `templates/standard-coa.json`.
 
 ## 6 File-naming convention
 
-* Save each template as **kebab-case** (`pit-bid.json`, `standard-coa.json`).
+* Save each template as **kebab-case** (`pit-bid.json`, `standard-fm-coa.json`).
 * The validator doesn’t care, but kebab-case improves CLI/URL readability.
 
 ---


### PR DESCRIPTION
## Summary
- update template_spec references to `standard-fm-coa.json`
- clarify example note for standard COA template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688910f5085c833396d14da8a06486f2