### PR TITLE
Implement canonical lookup for stored header mappings

### DIFF
--- a/tests/test_suggestion_store.py
+++ b/tests/test_suggestion_store.py
@@ -1,0 +1,41 @@
+import json
+from app_utils import suggestion_store
+
+
+def test_get_suggestions_canonical(monkeypatch, tmp_path):
+    path = tmp_path / "mapping_suggestions.json"
+    data = [
+        {
+            "template": "Demo",
+            "field": " Name ",
+            "type": "direct",
+            "formula": None,
+            "columns": ["ColA"],
+            "display": "ColA",
+        }
+    ]
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(suggestion_store, "SUGGESTION_FILE", path)
+
+    res = suggestion_store.get_suggestions("demo", "name")
+    assert res and res[0]["columns"][0] == "ColA"
+
+
+def test_add_suggestion_dedup(monkeypatch, tmp_path):
+    path = tmp_path / "mapping_suggestions.json"
+    path.write_text("[]")
+    monkeypatch.setattr(suggestion_store, "SUGGESTION_FILE", path)
+
+    base = {
+        "template": "Demo",
+        "field": "Name",
+        "type": "direct",
+        "formula": None,
+        "columns": ["ColA"],
+        "display": "ColA",
+    }
+    suggestion_store.add_suggestion(base)
+    suggestion_store.add_suggestion({**base, "field": " name ", "columns": ["colA"]})
+
+    saved = json.loads(path.read_text())
+    assert len(saved) == 1


### PR DESCRIPTION
## Summary
- normalize template and field names when fetching stored suggestions
- ignore whitespace and case so prior column mappings are recalled
- ensure deduplication when suggestions are added
- add unit tests for canonical matching and dedup logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a59c7f5908333ac31040e43a71790