### PR TITLE
Improve mapping suggestion overwrite

### DIFF
--- a/app_utils/suggestion_store.py
+++ b/app_utils/suggestion_store.py
@@ -2,18 +2,20 @@
 from pathlib import Path
 import json
 import re
-from typing import List, TypedDict
+import hashlib
+from typing import List, Optional, TypedDict
 
 SUGGESTION_FILE = Path("data/mapping_suggestions.json")
 
 
-class Suggestion(TypedDict):
+class Suggestion(TypedDict, total=False):
     template: str                 # e.g. "STANDARD_COA"
     field: str                    # e.g. "NET_CHANGE"
     type: str                     # "direct" | "formula"
     formula: str | None           # pythonic expr if type == "formula"
     columns: List[str]            # canonical source column names involved
     display: str                  # nice string for UI (optional for direct)
+    header_id: str                # optional fingerprint of source headers
 
 
 def _load() -> List[Suggestion]:
@@ -33,11 +35,32 @@ def _canon(text: str) -> str:
     return re.sub(r"\s+", "", text).lower()
 
 
-def add_suggestion(s: Suggestion) -> None:
+def _headers_id(headers: Optional[List[str]]) -> Optional[str]:
+    if not headers:
+        return None
+    canon = "|".join(sorted(_canon(h) for h in headers))
+    return hashlib.sha1(canon.encode()).hexdigest()[:8]
+
+
+def add_suggestion(s: Suggestion, headers: Optional[List[str]] | None = None) -> None:
     data = _load()
     t_c = _canon(s["template"])
     f_c = _canon(s["field"])
     cols_c = [_canon(c) for c in s.get("columns", [])]
+    h_id = s.get("header_id") or _headers_id(headers)
+    if h_id:
+        s = {**s, "header_id": h_id}
+    # Replace suggestion for same header set
+    for i, existing in enumerate(data):
+        if (
+            _canon(existing["template"]) == t_c
+            and _canon(existing["field"]) == f_c
+            and existing.get("header_id") == h_id
+        ):
+            data[i] = s
+            _save(data)
+            return
+    # Deduplicate exact suggestions
     for existing in data:
         if (
             _canon(existing["template"]) == t_c
@@ -45,17 +68,23 @@ def add_suggestion(s: Suggestion) -> None:
             and existing.get("type") == s.get("type")
             and existing.get("formula") == s.get("formula")
             and [_canon(c) for c in existing.get("columns", [])] == cols_c
+            and existing.get("header_id") == h_id
         ):
             return
     data.append(s)
     _save(data)
 
 
-def get_suggestions(template: str, field: str) -> List[Suggestion]:
+def get_suggestions(
+    template: str, field: str, headers: Optional[List[str]] | None = None
+) -> List[Suggestion]:
     t_c = _canon(template)
     f_c = _canon(field)
-    return [
-        s
-        for s in _load()
-        if _canon(s["template"]) == t_c and _canon(s["field"]) == f_c
-    ]
+    h_id = _headers_id(headers)
+    matches = []
+    for s in _load():
+        if _canon(s["template"]) == t_c and _canon(s["field"]) == f_c:
+            matches.append(s)
+    if h_id:
+        matches.sort(key=lambda x: 0 if x.get("header_id") == h_id else 1)
+    return matches

--- a/app_utils/ui/formula_dialog.py
+++ b/app_utils/ui/formula_dialog.py
@@ -134,7 +134,8 @@ def open_formula_dialog(df: pd.DataFrame, dialog_key: str) -> None:
                     "formula": expr,
                     "columns": re.findall(r"df\['([^']+)'\]", expr),
                     "display": st.session_state[f"{result_key}_display"],
-                }
+                },
+                headers=list(df.columns),
             )
             st.session_state.pop(expr_key, None)
             st.rerun()  # closes modal

--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -172,7 +172,9 @@ def render(layer, idx: int) -> None:
 
     for field in layer.fields:  # type: ignore
         key = field.key
-        for s in get_suggestions(st.session_state["current_template"], key):
+        for s in get_suggestions(
+            st.session_state["current_template"], key, headers=source_cols
+        ):
             if s["type"] == "direct":
                 for col in source_cols:
                     if col.lower() == s["columns"][0].lower():
@@ -215,7 +217,7 @@ def render(layer, idx: int) -> None:
         )
         if new_src:
             set_field_mapping(key, idx, {"src": new_src})  # user override
-            add_suggestion(  # learn it
+            add_suggestion(
                 {
                     "template": st.session_state["current_template"],
                     "field": key,
@@ -223,7 +225,8 @@ def render(layer, idx: int) -> None:
                     "formula": None,
                     "columns": [new_src],
                     "display": new_src,
-                }
+                },
+                headers=source_cols,
             )
         elif "src" in mapping.get(key, {}):
             set_field_mapping(key, idx, {})
@@ -239,15 +242,16 @@ def render(layer, idx: int) -> None:
             expr = st.session_state.pop(res_key)
             display = st.session_state.pop(res_disp_key, "")
             set_field_mapping(key, idx, {"expr": expr, "expr_display": display})
-            add_suggestion(  # store formula learning
+            add_suggestion(
                 {
                     "template": st.session_state["current_template"],
                     "field": key,
                     "type": "formula",
                     "formula": expr,
-                    "columns": [],  # filled by dialog store
+                    "columns": [],
                     "display": display or expr,
-                }
+                },
+                headers=source_cols,
             )
 
         # ── Expression / confidence cell ────────────────────────────────

--- a/tests/test_header_mapping.py
+++ b/tests/test_header_mapping.py
@@ -83,7 +83,7 @@ def test_saved_suggestion_overrides_fuzzy(monkeypatch, tmp_path):
 
     for f in fields:
         key = f.key
-        for s in suggestion_store.get_suggestions("simple-template", key):
+        for s in suggestion_store.get_suggestions("simple-template", key, headers=source_cols):
             if s["type"] == "direct":
                 for col in source_cols:
                     if col.lower() == s["columns"][0].lower():

--- a/tests/test_suggestion_store.py
+++ b/tests/test_suggestion_store.py
@@ -39,3 +39,25 @@ def test_add_suggestion_dedup(monkeypatch, tmp_path):
 
     saved = json.loads(path.read_text())
     assert len(saved) == 1
+
+
+def test_add_suggestion_replace_on_header(monkeypatch, tmp_path):
+    path = tmp_path / "mapping_suggestions.json"
+    path.write_text("[]")
+    monkeypatch.setattr(suggestion_store, "SUGGESTION_FILE", path)
+
+    base = {
+        "template": "Demo",
+        "field": "Name",
+        "type": "direct",
+        "formula": None,
+        "columns": ["ColA"],
+        "display": "ColA",
+    }
+    headers = ["ColA", "ColB"]
+    suggestion_store.add_suggestion(base, headers=headers)
+    suggestion_store.add_suggestion({**base, "columns": ["ColB"]}, headers=headers)
+
+    saved = json.loads(path.read_text())
+    assert len(saved) == 1
+    assert saved[0]["columns"] == ["ColB"]


### PR DESCRIPTION
## Summary
- track `header_id` for mapping suggestions
- overwrite suggestions when the same header layout is seen again
- prioritize suggestions by header when retrieving
- pass header info from UI and formula dialog
- test header-aware overwrite logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a64fe7850833395e0a611d7749c1a