### PR TITLE
Improve reset and mapping confirm behavior

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,18 +61,29 @@ def main():
                 del st.session_state[k]
 
     def do_reset() -> None:
-        """Clear uploaded file and mapping progress."""
+        """Clear uploaded file, mappings, and export state."""
+        prefixes = [
+            "layer_confirmed_",
+            "header_",
+            "lookup_",
+            "computed_",
+        ]
         for k in list(st.session_state.keys()):
-            if k.startswith("layer_confirmed_"):
+            if any(k.startswith(p) for p in prefixes):
                 st.session_state.pop(k)
         for k in [
             "uploaded_file",
             "upload_data_file",
+            "upload_sheet",
+            "upload_sheets",
             "template",
             "template_name",
             "selected_template_file",
             "current_template",
             "auto_computed_confirm",
+            "export_complete",
+            "export_logs",
+            "final_json",
         ]:
             st.session_state.pop(k, None)
         st.session_state["current_step"] = 0

--- a/app_utils/ui/header_utils.py
+++ b/app_utils/ui/header_utils.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+"""Helper functions for the header mapping UI."""
+
+import re
+import streamlit as st
+from app_utils.suggestion_store import add_suggestion
+from app_utils.template_builder import (
+    build_lookup_layer,
+    build_computed_layer,
+    save_template_file,
+)
+from app_utils.ui_utils import set_steps_from_template
+
+
+def set_field_mapping(field_key: str, idx: int, value: dict) -> None:
+    """Persist mapping for ``field_key`` and mark session dirty if changed."""
+    map_key = f"header_mapping_{idx}"
+    mapping = st.session_state.setdefault(map_key, {})
+    if mapping.get(field_key) != value:
+        mapping[field_key] = value
+        st.session_state[map_key] = mapping
+        st.session_state["unsaved_changes"] = True
+
+
+def remove_field(field_key: str, idx: int) -> None:
+    """Delete a user-added field from session state."""
+    map_key = f"header_mapping_{idx}"
+    extra_key = f"header_extra_fields_{idx}"
+    mapping = st.session_state.get(map_key, {})
+    mapping.pop(field_key, None)
+    st.session_state[map_key] = mapping
+    extras = st.session_state.get(extra_key, [])
+    if field_key in extras:
+        extras.remove(field_key)
+        st.session_state[extra_key] = extras
+    tpl = st.session_state.get("template")
+    if tpl:
+        layer = tpl["layers"][idx]
+        layer["fields"] = [
+            f for f in layer.get("fields", []) if f.get("key") != field_key
+        ]
+        st.session_state["template"] = tpl
+    st.session_state["unsaved_changes"] = True
+
+
+def add_field(field_key: str, idx: int) -> None:
+    """Append a new field to session state and template."""
+    map_key = f"header_mapping_{idx}"
+    extra_key = f"header_extra_fields_{idx}"
+    mapping = st.session_state.setdefault(map_key, {})
+    mapping[field_key] = {}
+    st.session_state[map_key] = mapping
+    extras = st.session_state.setdefault(extra_key, [])
+    if field_key not in extras:
+        extras.append(field_key)
+        st.session_state[extra_key] = extras
+    tpl = st.session_state.get("template")
+    if tpl:
+        layer = tpl["layers"][idx]
+        if not any(f.get("key") == field_key for f in layer.get("fields", [])):
+            layer.setdefault("fields", []).append({"key": field_key, "required": False})
+        st.session_state["template"] = tpl
+    st.session_state["unsaved_changes"] = True
+
+
+def append_lookup_layer(
+    source_field: str,
+    target_field: str,
+    dictionary_sheet: str,
+    sheet: str | None = None,
+) -> None:
+    """Append a lookup layer to the in-memory template."""
+    tpl = st.session_state.get("template")
+    if not tpl:
+        return
+    layer = build_lookup_layer(
+        source_field, target_field, dictionary_sheet, sheet=sheet
+    )
+    tpl.setdefault("layers", []).append(layer)
+    st.session_state["template"] = tpl
+    set_steps_from_template(tpl["layers"])
+    st.session_state["unsaved_changes"] = True
+
+
+def append_computed_layer(
+    target_field: str, expression: str, sheet: str | None = None
+) -> None:
+    """Append a computed layer to the in-memory template."""
+    tpl = st.session_state.get("template")
+    if not tpl:
+        return
+    layer = build_computed_layer(target_field, expression, sheet=sheet)
+    tpl.setdefault("layers", []).append(layer)
+    st.session_state["template"] = tpl
+    set_steps_from_template(tpl["layers"])
+    st.session_state["unsaved_changes"] = True
+
+
+def save_current_template() -> str | None:
+    """Save ``st.session_state['template']`` using ``save_template_file``."""
+    tpl = st.session_state.get("template")
+    if not tpl:
+        return None
+    name = save_template_file(tpl)
+    st.session_state["unsaved_changes"] = False
+    return name
+
+
+def persist_suggestions_from_mapping(layer, mapping: dict, source_cols: list[str]) -> None:
+    """Persist suggestions for the provided mapping."""
+    for field in layer.fields:  # type: ignore
+        info = mapping.get(field.key, {})
+        if "src" in info:
+            add_suggestion(
+                {
+                    "template": st.session_state["current_template"],
+                    "field": field.key,
+                    "type": "direct",
+                    "formula": None,
+                    "columns": [info["src"]],
+                    "display": info["src"],
+                },
+                headers=source_cols,
+            )
+        elif "expr" in info:
+            cols = re.findall(r"df\['([^']+)'\]", info["expr"])
+            add_suggestion(
+                {
+                    "template": st.session_state["current_template"],
+                    "field": field.key,
+                    "type": "formula",
+                    "formula": info["expr"],
+                    "columns": cols,
+                    "display": info.get("expr_display", info["expr"]),
+                },
+                headers=source_cols,
+            )
+

--- a/tests/test_reset_button.py
+++ b/tests/test_reset_button.py
@@ -80,6 +80,10 @@ def run_app(monkeypatch):
         "template_name": "Demo",
         "current_template": "Demo",
         "layer_confirmed_0": True,
+        "export_complete": True,
+        "export_logs": ["log"],
+        "final_json": {"a": 1},
+        "header_mapping_0": {"A": {"src": "A"}},
     })
     sys.modules.pop("app", None)
     importlib.import_module("app")
@@ -90,3 +94,5 @@ def test_reset_button_triggers_rerun(monkeypatch):
     st = run_app(monkeypatch)
     assert st.rerun_called is True
     assert "uploaded_file" not in st.session_state
+    assert "export_complete" not in st.session_state
+    assert "header_mapping_0" not in st.session_state


### PR DESCRIPTION
## Summary
- clear mapping and export state when Reset is used
- move header helpers into `app_utils.ui.header_utils`
- persist mapping suggestions when confirming header mapping
- remove Save Template button from mapping step
- test updates for new reset behavior and suggestion persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a6732670483338d7f4b3442f1d5d2