### PR TITLE
Fix ComputedLayer formula access

### DIFF
--- a/pages/steps/computed.py
+++ b/pages/steps/computed.py
@@ -20,7 +20,11 @@ def render(layer, idx: int):
             st.session_state["uploaded_file"], sheet_name=sheet_name
         )
 
-    strategy = getattr(layer, "formula", {}).get("strategy", "first_available")
+    formula = getattr(layer, "formula", None)
+    if isinstance(formula, dict):
+        strategy = formula.get("strategy", "first_available")
+    else:
+        strategy = getattr(formula, "strategy", "first_available")
 
     # 1. Decide Direct vs Computed
     mode_key = f"computed_mode_{idx}"

--- a/tests/test_computed_page.py
+++ b/tests/test_computed_page.py
@@ -1,0 +1,63 @@
+import sys
+import pandas as pd
+import pytest
+
+from schemas.template_v2 import ComputedLayer, ComputedFormula
+from pages.steps import computed as computed_step
+
+
+class DummyStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, object] = {}
+
+    class Spinner:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc) -> None:
+            pass
+
+    def header(self, *a, **k):
+        pass
+
+    success = info = warning = error = header
+
+    def spinner(self, *a, **k):
+        return self.Spinner()
+
+    def radio(self, label, options, key=None):  # noqa: D401 - doc string not needed
+        return options[0]
+
+    def selectbox(self, label, options, index=0, key=None):
+        return options[index]
+
+    def button(self, *a, **k):
+        return False
+
+
+from _pytest.monkeypatch import MonkeyPatch
+
+
+def patch_streamlit(monkeypatch: MonkeyPatch) -> DummyStreamlit:
+    st = DummyStreamlit()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+    monkeypatch.setattr(computed_step, "st", st)
+    return st
+
+
+def test_render_with_pydantic_layer(monkeypatch: MonkeyPatch) -> None:
+    st = patch_streamlit(monkeypatch)
+
+    monkeypatch.setattr(
+        computed_step,
+        "read_tabular_file",
+        lambda *_a, **_k: (pd.DataFrame({"A": [1]}), ["A"]),
+    )
+
+    st.session_state.update({"uploaded_file": object(), "upload_sheet": 0})
+
+    layer = ComputedLayer(type="computed", target_field="X", formula=ComputedFormula())
+    computed_step.render(layer, 0)
+
+    assert "computed_result_0" in st.session_state
+


### PR DESCRIPTION
## Summary
- handle `ComputedFormula` object inside computed step
- add regression test for pydantic layer rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a7a11a71c833391dd95cf38f08ad1