### PR TITLE
Simplify template builder UI

### DIFF
--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -176,11 +176,10 @@ JSON together with any log messages from that run.
 
 ### 4.1\u2003Template Builder helpers
 
-The `app_utils.template_builder` module offers convenience functions for programmatically
-assembling templates. Use `build_lookup_layer` or `build_computed_layer` to create
-layer objects and pass them to `build_template()` along with the mandatory header
-layer. The builder validates the final structure against the schema so any
-mistakes raise a `ValidationError`.
+The `app_utils.template_builder` module provides utilities for building the
+initial header layer via `build_header_template` and saving it with
+`build_template()`. Lookup mappings and computed formulas are added later by the
+mapping wizard when the user defines them.
 
 ---
 

--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -135,55 +135,6 @@ def show() -> None:
             placeholder='{"url": "https://example.com/hook"}',
         )
 
-        extra_layers = st.session_state.setdefault("tm_extra_layers", [])
-
-        st.subheader("Add Lookup Layer")
-        lcol1, lcol2 = st.columns([1, 1])
-        src = lcol1.selectbox(
-            "Source column",
-            options=[""] + columns,
-            key="tm_lookup_src",
-        )
-        tgt = lcol1.text_input("Target field", key="tm_lookup_tgt")
-        dsh = lcol2.text_input("Dictionary sheet", key="tm_lookup_dict")
-        lsheet = lcol2.text_input(
-            "Sheet (optional)", key="tm_lookup_sheet", placeholder="Sheet1"
-        )
-        if st.button("Add Lookup Layer") and src and tgt and dsh:
-            extra_layers.append(
-                build_lookup_layer(src, tgt, dsh, sheet=lsheet or None)
-            )
-            st.session_state["tm_lookup_src"] = ""
-            st.session_state["tm_lookup_tgt"] = ""
-            st.session_state["tm_lookup_dict"] = ""
-            st.session_state["tm_lookup_sheet"] = ""
-            st.session_state["unsaved_changes"] = True
-
-        st.subheader("Add Computed Layer")
-        ccol1, ccol2 = st.columns([1, 1])
-        ctgt = ccol1.text_input("Computed target", key="tm_comp_tgt")
-        expr = ccol1.text_input("Expression (optional)", key="tm_comp_expr")
-        csheet = ccol2.text_input(
-            "Sheet (optional)", key="tm_comp_sheet", placeholder="Sheet1"
-        )
-        if st.button("Add Computed Layer") and ctgt:
-            extra_layers.append(
-                build_computed_layer(ctgt, expr or None, sheet=csheet or None)
-            )
-            st.session_state["tm_comp_tgt"] = ""
-            st.session_state["tm_comp_expr"] = ""
-            st.session_state["tm_comp_sheet"] = ""
-            st.session_state["unsaved_changes"] = True
-
-        if extra_layers:
-            st.markdown("**Additional layers:**")
-            for i, l in enumerate(extra_layers):
-                st.json(l)
-                if st.button("Remove", key=f"rm_layer_{i}"):
-                    extra_layers.pop(i)
-                    st.session_state["tm_extra_layers"] = extra_layers
-                    st.session_state["unsaved_changes"] = True
-                    st.rerun()
 
     name = st.session_state.get("tm_name", "")
 
@@ -192,8 +143,7 @@ def show() -> None:
         post_txt = st.session_state.get("tm_postprocess", "").strip()
         post_obj = json.loads(post_txt) if post_txt else None
         header_only = build_header_template(name, selected_cols, req_map)
-        all_layers = [header_only["layers"][0]] + st.session_state.get("tm_extra_layers", [])
-        tpl = build_template(name, all_layers, post_obj)
+        tpl = build_template(name, [header_only["layers"][0]], post_obj)
         with st.spinner("Saving template..."):
             try:
                 Template.model_validate(tpl)
@@ -206,7 +156,6 @@ def show() -> None:
                 st.session_state.pop("tm_required", None)
                 st.session_state.pop("tm_field_select", None)
                 st.session_state.pop("tm_sheet", None)
-                st.session_state.pop("tm_extra_layers", None)
                 st.rerun()
 
     st.divider()

--- a/tests/test_header_mapping.py
+++ b/tests/test_header_mapping.py
@@ -6,9 +6,6 @@ from app_utils.ui.header_utils import (
     remove_field,
     add_field,
     set_field_mapping,
-    append_lookup_layer,
-    append_computed_layer,
-    save_current_template,
     persist_suggestions_from_mapping,
 )
 import streamlit as st
@@ -155,21 +152,6 @@ def test_persist_template_clears_unsaved(monkeypatch):
     assert st.session_state["unsaved_changes"] is False
     sys.modules.pop("pages.template_manager", None)
 
-
-def test_append_layers_and_save(monkeypatch, tmp_path):
-    st.session_state.clear()
-    st.session_state["template"] = {"template_name": "demo", "layers": []}
-
-    append_lookup_layer("SRC", "TGT", "dict")
-    append_computed_layer("TOTAL", "df['A']")
-    assert len(st.session_state["template"]["layers"]) == 2
-
-    monkeypatch.setattr(
-        "app_utils.ui.header_utils.save_template_file", lambda tpl: "demo-saved"
-    )
-    name = save_current_template()
-    assert name == "demo-saved"
-    assert st.session_state["unsaved_changes"] is False
 
 
 def test_persist_suggestions_from_mapping(monkeypatch, tmp_path):

--- a/tests/test_template_manager_ui.py
+++ b/tests/test_template_manager_ui.py
@@ -1,7 +1,6 @@
 import types
 import importlib
 import sys
-from app_utils.template_builder import build_lookup_layer, build_computed_layer
 
 class DummySidebar:
     def __init__(self) -> None:
@@ -234,58 +233,4 @@ def test_suggest_required_fields_without_file(monkeypatch):
     assert calls["read"] == 0
 
 
-def test_add_lookup_and_computed_layers(monkeypatch):
-    dummy_file = types.SimpleNamespace(name="demo.csv")
-
-    def btn(label, *a, **k):
-        return label in {"Add Lookup Layer", "Add Computed Layer"}
-
-    dummy = run_manager(
-        monkeypatch,
-        uploaded=dummy_file,
-        cols=["A"],
-        button_patch=btn,
-        session_state={
-            "tm_columns": ["A"],
-            "tm_lookup_src": "A",
-            "tm_lookup_tgt": "B",
-            "tm_lookup_dict": "dict",
-            "tm_comp_tgt": "TOTAL",
-            "tm_comp_expr": "df['A']",
-        },
-    )
-
-    layers = dummy.session_state.get("tm_extra_layers")
-    assert len(layers) == 2
-    assert layers[0]["type"] == "lookup"
-    assert layers[1]["type"] == "computed"
-
-
-def test_save_template_includes_extra_layers(monkeypatch):
-    dummy_file = types.SimpleNamespace(name="demo.csv")
-    extra = [
-        build_lookup_layer("A", "A", "dict"),
-        build_computed_layer("TOTAL", "df['A']"),
-    ]
-    captured = {}
-
-    def fake_builder(name, layers, post=None):
-        captured["layers"] = layers
-        return {"template_name": name, "layers": layers}
-
-    dummy = run_manager(
-        monkeypatch,
-        uploaded=dummy_file,
-        cols=["A"],
-        button_patch=lambda label, *a, **k: label == "Save Template",
-        builder=fake_builder,
-        session_state={
-            "tm_columns": ["A"],
-            "tm_field_select": {"A": "required"},
-            "tm_name": "demo",
-            "tm_extra_layers": extra,
-        },
-    )
-
-    assert len(captured["layers"]) == 1 + len(extra)
 


### PR DESCRIPTION
## Summary
- remove lookup/computed layer options from template manager UI
- adjust docs to clarify that formulas are added during mapping
- drop related tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_688aa70bf09c83339211c0de68c580c8