### PR TITLE
refactor: load SQL config from individual env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ OPENAI_API_KEY = "your-openai-key"
 
 Streamlit will automatically load this file when running the app.
 
+### Database configuration
+
+To enable operation and customer lookups, set the following environment variables
+or add them to `.streamlit/secrets.toml`:
+
+- `SQL_SERVER`
+- `SQL_DATABASE`
+- `SQL_USERNAME`
+- `SQL_PASSWORD`
+
+Alternatively, a full connection string may be supplied via
+`AZURE_SQL_CONN_STRING`.
+
 ## Command Line Interface
 
 Run the mapping pipeline directly from the terminal using `cli.py`:

--- a/app.py
+++ b/app.py
@@ -103,7 +103,11 @@ def main():
     with st.sidebar:
         if user_email:
             st.subheader("Select Operation")
-            op_codes = fetch_operation_codes(user_email)
+            try:
+                op_codes = fetch_operation_codes(user_email)
+            except RuntimeError as err:
+                st.error(f"Operation lookup failed: {err}")
+                return
             if not op_codes:
                 st.error("No operations available.")
                 return
@@ -178,8 +182,12 @@ def main():
             st.session_state.get("customer_options") is None
             or st.session_state.get("customer_scac") != scac
         ):
-            st.session_state["customer_options"] = fetch_customers(scac)
-            st.session_state["customer_scac"] = scac
+            try:
+                st.session_state["customer_options"] = fetch_customers(scac)
+                st.session_state["customer_scac"] = scac
+            except RuntimeError as err:
+                st.error(f"Customer lookup failed: {err}")
+                return
         cust_records = st.session_state["customer_options"]
         cust_names = [c["BILLTO_NAME"] for c in cust_records]
         if cust_names:

--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 """Helpers for Azure SQL queries."""
 
-from typing import Dict, List, Optional
+from typing import Dict, List
 import os
+from pathlib import Path
+
+try:  # pragma: no cover - handled in tests via monkeypatch
+    import tomllib  # Python 3.11+
+except Exception:  # pragma: no cover
+    tomllib = None  # type: ignore
 
 try:  # pragma: no cover - handled in tests via monkeypatch
     import pyodbc  # type: ignore
@@ -11,19 +17,50 @@ except Exception:  # pragma: no cover - if pyodbc missing or misconfigured
     pyodbc = None  # type: ignore
 
 
-def _connect() -> Optional["pyodbc.Connection"]:
-    """Return a database connection if configured."""
-    conn_str = os.getenv("AZURE_SQL_CONN_STRING")
-    if not conn_str or not pyodbc:
-        return None
+def _load_secret(key: str) -> str | None:
+    """Return a config value from env or `.streamlit/secrets.toml`."""
+    if val := os.getenv(key):
+        return val
+    secrets_path = Path(".streamlit") / "secrets.toml"
+    if tomllib and secrets_path.exists():  # pragma: no cover - executed in app
+        with secrets_path.open("rb") as fh:
+            secrets = tomllib.load(fh)
+        raw = secrets.get(key)
+        return str(raw) if raw is not None else None
+    return None
+
+
+def _build_conn_str() -> str:
+    """Assemble an ODBC connection string from config."""
+    server = _load_secret("SQL_SERVER")
+    database = _load_secret("SQL_DATABASE")
+    username = _load_secret("SQL_USERNAME")
+    password = _load_secret("SQL_PASSWORD")
+    if not all([server, database, username, password]):
+        raise RuntimeError(
+            "SQL connection is not configured; set SQL_SERVER, SQL_DATABASE, "
+            "SQL_USERNAME, and SQL_PASSWORD"
+        )
+    return (
+        "DRIVER={ODBC Driver 18 for SQL Server};"
+        f"SERVER={server};DATABASE={database};UID={username};PWD={password}"
+    )
+
+
+def _connect() -> "pyodbc.Connection":
+    """Return a database connection or raise ``RuntimeError`` if misconfigured."""
+    if not pyodbc:
+        raise RuntimeError("pyodbc is not installed")
+    conn_str = os.getenv("AZURE_SQL_CONN_STRING") or _build_conn_str()
     return pyodbc.connect(conn_str)
 
 
 def fetch_operation_codes(email: str) -> List[str]:
     """Return sorted operation codes for a user email."""
-    conn = _connect()
-    if not conn:
-        return []
+    try:
+        conn = _connect()
+    except RuntimeError as err:  # pragma: no cover - exercised in integration
+        raise RuntimeError(f"Operation code lookup failed: {err}") from err
     with conn:
         cur = conn.cursor()
         cur.execute(
@@ -36,9 +73,10 @@ def fetch_operation_codes(email: str) -> List[str]:
 
 def fetch_customers(operational_scac: str) -> List[Dict[str, str]]:
     """Return customer records for a given operational SCAC."""
-    conn = _connect()
-    if not conn:
-        return []
+    try:
+        conn = _connect()
+    except RuntimeError as err:  # pragma: no cover - exercised in integration
+        raise RuntimeError(f"Customer lookup failed: {err}") from err
     with conn:
         cur = conn.cursor()
         cur.execute(


### PR DESCRIPTION
## Summary
- build SQL connection string from `SQL_SERVER`, `SQL_DATABASE`, `SQL_USERNAME`, `SQL_PASSWORD` or `AZURE_SQL_CONN_STRING`
- surface database failures in Streamlit sidebar for operation and customer lookups
- document required SQL environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68927df0a68c8333b3fa1bd9bc939f99