### PR TITLE
Insert pit-bid mappings into RFP_OBJECT_DATA

### DIFF
--- a/app.py
+++ b/app.py
@@ -267,7 +267,13 @@ def main():
                         st.session_state["uploaded_file"], sheet_name=sheet
                     )
                     guid = str(uuid.uuid4())
-                    logs = run_postprocess_if_configured(template_obj, df, guid)
+                    logs = run_postprocess_if_configured(
+                        template_obj,
+                        df,
+                        guid,
+                        st.session_state.get("operation_code"),
+                        st.session_state.get("customer_name"),
+                    )
                     final_json = build_output_template(
                         template_obj, st.session_state, guid
                     )

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -90,7 +90,8 @@ def run_app(monkeypatch):
     )
     monkeypatch.setattr("app_utils.azure_sql.fetch_customers", lambda scac: [])
     called: dict[str, object] = {}
-    def fake_runner(tpl, df, guid=None):
+
+    def fake_runner(tpl, df, guid=None, *args):
         called["run"] = True
         called["guid"] = guid
         return ["ok"]


### PR DESCRIPTION
## Summary
- add Azure SQL helper to insert mapped PIT BID rows into `dbo.RFP_OBJECT_DATA`, filling ad-hoc columns and metadata
- wire postprocess runner to call the insert when the pit-bid template is used and operation/customer info is provided
- pass operation code and customer name from the Streamlit export step
- cover database insert and new postprocess behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689291db8ee083339a79ab96c85a3639