### PR TITLE
Handle blank numeric fields in pit bid insert

### DIFF
--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -185,3 +185,43 @@ def test_insert_pit_bid_rows(monkeypatch):
     assert captured["params"][14] == "bar"  # ADHOC_INFO1
     assert captured["params"][24] == 100  # FM_MILES
     assert len(captured["params"]) == 29
+
+
+def test_insert_pit_bid_rows_blanks(monkeypatch):
+    captured = {}
+
+    class FakeCursor:
+        def execute(self, query, params):  # pragma: no cover - executed via call
+            captured["params"] = params
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(azure_sql, "_connect", lambda: FakeConn())
+    df = pd.DataFrame(
+        {
+            "Lane ID": ["L1"],
+            "Origin City": ["OC"],
+            "Orig State": ["OS"],
+            "Orig Zip (5 or 3)": ["11111"],
+            "Destination City": ["DC"],
+            "Dest State": ["DS"],
+            "Dest Zip (5 or 3)": ["22222"],
+            "Bid Volume": [""],
+            "LH Rate": [""],
+            "Bid Miles": [""],
+            "Tolls": [""],
+        }
+    )
+    azure_sql.insert_pit_bid_rows(df, "OP", "Customer", "guid")
+    assert captured["params"][9] is None  # BID_VOLUME
+    assert captured["params"][10] is None  # LH_RATE
+    assert captured["params"][24] is None  # FM_MILES
+    assert captured["params"][25] is None  # FM_TOLLS


### PR DESCRIPTION
## Summary
- sanitize numeric inputs before inserting pit bid rows into SQL
- extend tests for blank numeric values in pit bid rows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892b5bc411483339abdb746e3801160