### PR TITLE
Fix PIT BID inserts and optional customer selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,15 +190,21 @@ def main():
         cust_records = st.session_state["customer_options"]
         cust_names = [c["BILLTO_NAME"] for c in cust_records]
         if cust_names:
-            cust_idx = 0
+            options = [""] + cust_names
+            idx = 0
             if st.session_state.get("customer_name") in cust_names:
-                cust_idx = cust_names.index(st.session_state["customer_name"])
+                idx = cust_names.index(st.session_state["customer_name"]) + 1
             selected_name = st.selectbox(
-                "Customer", cust_names, index=cust_idx, key="customer_name"
+                "Customer (optional)", options, index=idx, key="customer_name_select"
             )
-            st.session_state["selected_customer"] = next(
-                c for c in cust_records if c["BILLTO_NAME"] == selected_name
-            )
+            if selected_name:
+                st.session_state["customer_name"] = selected_name
+                st.session_state["selected_customer"] = next(
+                    c for c in cust_records if c["BILLTO_NAME"] == selected_name
+                )
+            else:
+                st.session_state["customer_name"] = None
+                st.session_state["selected_customer"] = None
         else:
             st.warning("No customers found for selected operation.")
 

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -42,7 +42,7 @@ def run_postprocess_if_configured(
 
     logs: List[str] = []
     slug = slugify(template.template_name)
-    if slug == "pit-bid" and operation_cd and customer_name:
+    if slug == "pit-bid" and operation_cd:
         from app_utils.azure_sql import insert_pit_bid_rows
 
         insert_pit_bid_rows(df, operation_cd, customer_name, process_guid)

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -60,9 +60,9 @@ def test_if_configured_runs_pit_bid_insert(monkeypatch):
     monkeypatch.setattr('app_utils.azure_sql.insert_pit_bid_rows', fake_insert)
     df = pd.DataFrame({'Lane ID': ['L1']})
     run_postprocess_if_configured(
-        tpl, df, process_guid='guid', operation_cd='OP', customer_name='Cust'
+        tpl, df, process_guid='guid', operation_cd='OP', customer_name=None
     )
     assert called['hit'][0] == 'OP'
-    assert called['hit'][1] == 'Cust'
+    assert called['hit'][1] is None
     assert called['hit'][2] == 'guid'
 


### PR DESCRIPTION
## Summary
- allow optional customer selection in PIT BID wizard
- map PIT BID columns directly and send unknowns to NULL
- support miles/tolls and customer values from data, set VOLUME_FREQUENCY NULL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892b9ef0ba083338f7661d0edb0797c