### PR TITLE
Apply header mapping and alias fixes

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -126,15 +126,23 @@ def insert_pit_bid_rows(
     """
 
     field_aliases: Dict[str, List[str]] = {
-        "LANE_ID": ["Lane ID", "LANE_ID"],
+        "LANE_ID": ["Lane ID", "Lane Code", "LANE_ID"],
         "ORIG_CITY": ["Origin City", "ORIG_CITY"],
-        "ORIG_ST": ["Orig State", "ORIG_ST"],
-        "ORIG_POSTAL_CD": ["Orig Zip (5 or 3)", "ORIG_POSTAL_CD"],
+        "ORIG_ST": ["Orig State", "Origin State", "ORIG_ST"],
+        "ORIG_POSTAL_CD": [
+            "Orig Zip (5 or 3)",
+            "Origin Zip",
+            "ORIG_POSTAL_CD",
+        ],
         "DEST_CITY": ["Destination City", "DEST_CITY"],
-        "DEST_ST": ["Dest State", "DEST_ST"],
-        "DEST_POSTAL_CD": ["Dest Zip (5 or 3)", "DEST_POSTAL_CD"],
+        "DEST_ST": ["Dest State", "Destination State", "DEST_ST"],
+        "DEST_POSTAL_CD": [
+            "Dest Zip (5 or 3)",
+            "Destination Zip",
+            "DEST_POSTAL_CD",
+        ],
         "BID_VOLUME": ["Bid Volume", "BID_VOLUME"],
-        "LH_RATE": ["LH Rate", "LH_RATE"],
+        "LH_RATE": ["LH Rate", "Linehaul Rate", "LH_RATE"],
         "RFP_MILES": ["Bid Miles", "Miles", "RFP Miles", "RFP_MILES"],
         "RFP_TOLLS": ["Tolls", "RFP Tolls", "RFP_TOLLS"],
         "CUSTOMER_NAME": [

--- a/app_utils/dataframe_transform.py
+++ b/app_utils/dataframe_transform.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""DataFrame transformation utilities."""
+
+from typing import Any
+import pandas as pd
+
+
+def apply_header_mappings(df: pd.DataFrame, template: Any) -> pd.DataFrame:
+    """Return a new DataFrame with columns renamed per template mappings.
+
+    Handles both direct header mappings and computed expressions.
+    """
+    out = df.copy()
+    for layer in getattr(template, "layers", []):
+        if getattr(layer, "type", None) != "header":
+            continue
+        for field in getattr(layer, "fields", []):
+            src = getattr(field, "source", None)
+            expr = getattr(field, "expression", None)
+            if src and src in out.columns:
+                out = out.rename(columns={src: field.key})
+            elif expr:
+                out[field.key] = eval(expr, {"df": out})  # controlled templates
+    return out

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -7,6 +7,7 @@ import os
 import pandas as pd
 from schemas.template_v2 import PostprocessSpec, Template
 from app_utils.template_builder import slugify
+from app_utils.dataframe_transform import apply_header_mappings
 
 
 def run_postprocess(
@@ -41,6 +42,7 @@ def run_postprocess_if_configured(
     """Run optional postprocess hooks and DB inserts based on ``template``."""
 
     logs: List[str] = []
+    df = apply_header_mappings(df, template)
     slug = slugify(template.template_name)
     if slug == "pit-bid" and operation_cd:
         from app_utils.azure_sql import insert_pit_bid_rows

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -265,6 +265,47 @@ def test_insert_pit_bid_rows_aliases(monkeypatch):
     assert captured["params"][24] == 123
 
 
+def test_insert_pit_bid_rows_new_aliases(monkeypatch):
+    captured = {}
+
+    class FakeCursor:
+        def execute(self, query, params):  # pragma: no cover - executed via call
+            captured["params"] = params
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(azure_sql, "_connect", lambda: FakeConn())
+    df = pd.DataFrame(
+        {
+            "Lane Code": ["L1"],
+            "Origin State": ["OS"],
+            "Origin Zip": ["11111"],
+            "Destination State": ["DS"],
+            "Destination Zip": ["22222"],
+            "Bid Volume": [7],
+            "Linehaul Rate": [1.5],
+            "Bid Miles": [321],
+        }
+    )
+    azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
+    assert captured["params"][2] == "L1"
+    assert captured["params"][4] == "OS"
+    assert captured["params"][5] == "11111"
+    assert captured["params"][7] == "DS"
+    assert captured["params"][8] == "22222"
+    assert captured["params"][9] == 7
+    assert captured["params"][10] == 1.5
+    assert captured["params"][24] == 321
+
+
 def test_insert_pit_bid_rows_customer_column(monkeypatch):
     captured = {}
 

--- a/tests/test_dataframe_transform.py
+++ b/tests/test_dataframe_transform.py
@@ -1,0 +1,23 @@
+import types
+import pandas as pd
+
+from app_utils.dataframe_transform import apply_header_mappings
+
+
+def test_apply_header_mappings_renames_and_computes():
+    template = types.SimpleNamespace(
+        layers=[
+            types.SimpleNamespace(
+                type="header",
+                fields=[
+                    types.SimpleNamespace(key="X", source="A"),
+                    types.SimpleNamespace(key="Y", expression="df['X'] * 2"),
+                ],
+            )
+        ]
+    )
+    df = pd.DataFrame({"A": [3]})
+    out = apply_header_mappings(df, template)
+    assert list(out.columns) == ["X", "Y"]
+    assert out.loc[0, "X"] == 3
+    assert out.loc[0, "Y"] == 6


### PR DESCRIPTION
## Summary
- expand PIT BID header aliases to catch client-specific names like "Lane Code" and "Linehaul Rate"
- apply template-driven header mappings before inserts and postprocess hooks
- add DataFrame transformation helper and unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689387d0b6fc8333a6cd4a2aad234358