### PR TITLE
feat: allow mapped csv export

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import pandas as pd
 
 from schemas.template_v2 import Template
-from app_utils.excel_utils import excel_to_json
+from app_utils.excel_utils import excel_to_json, save_mapped_csv
 from app_utils.mapping_utils import suggest_header_mapping, match_lookup_values
 from app_utils.mapping.header_layer import apply_gpt_header_fallback
 from app_utils.mapping.computed_layer import resolve_computed_layer
@@ -54,6 +54,11 @@ def main() -> None:
     parser.add_argument("template", type=Path, help="Path to template JSON")
     parser.add_argument("input_file", type=Path, help="Path to CSV/Excel source")
     parser.add_argument("output", type=Path, help="Destination for mapped JSON")
+    parser.add_argument(
+        "--csv-output",
+        type=Path,
+        help="Optional path to save mapped CSV",
+    )
     args = parser.parse_args()
 
     template = load_template(args.template)
@@ -63,6 +68,9 @@ def main() -> None:
 
     with args.output.open("w") as f:
         json.dump(mapped, f, indent=2)
+
+    if args.csv_output:
+        save_mapped_csv(df, mapped, args.csv_output)
 
     # Trigger optional post-process actions
     run_postprocess_if_configured(template, df)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,24 @@ def test_cli_basic(tmp_path: Path):
     assert fields['Name'] == 'Name'
     assert fields['Value'] == 'Value'
 
+
+def test_cli_csv_output(tmp_path: Path):
+    tpl = Path('tests/fixtures/simple-template.json')
+    src = Path('tests/fixtures/simple.csv')
+    out_json = tmp_path / 'out.json'
+    out_csv = tmp_path / 'out.csv'
+
+    subprocess.check_call([
+        'python',
+        'cli.py',
+        str(tpl),
+        str(src),
+        str(out_json),
+        '--csv-output',
+        str(out_csv),
+    ])
+
+    content = out_csv.read_text().strip().splitlines()
+    assert content[0] == 'Name,Value'
+    assert content[1] == 'Alice,1'
+

--- a/tests/test_excel_utils.py
+++ b/tests/test_excel_utils.py
@@ -1,5 +1,7 @@
+import pandas as pd
 import app_utils.excel_utils as excel_utils
-from app_utils.excel_utils import list_sheets, read_tabular_file
+from pathlib import Path
+from app_utils.excel_utils import list_sheets, read_tabular_file, save_mapped_csv
 
 
 def test_list_sheets():
@@ -83,3 +85,24 @@ def test_list_sheets_closes_temp(monkeypatch, tmp_path):
 
     sheets = excel_utils.list_sheets(DummyUpload())
     assert sheets == ["First"]
+
+
+def test_save_mapped_csv(tmp_path):
+    df = pd.DataFrame({"A": [1], "B": [2]})
+    tpl = {
+        "template_name": "t",
+        "layers": [
+            {
+                "type": "header",
+                "fields": [
+                    {"key": "X", "source": "A"},
+                    {"key": "Y", "source": "B"},
+                ],
+            }
+        ],
+    }
+    out_path = tmp_path / "mapped.csv"
+    save_mapped_csv(df, tpl, out_path)
+    text = out_path.read_text().strip().splitlines()
+    assert text[0] == "X,Y"
+    assert text[1] == "1,2"


### PR DESCRIPTION
## Summary
- map dataframe headers to template keys and persist via `save_mapped_csv`
- add `--csv-output` flag to CLI
- enable mapped CSV download in Streamlit header step and export completion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893a9293b34833383ff783dab1022f3