### PR TITLE
Handle sequential ADHOC columns

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -236,8 +236,10 @@ def insert_pit_bid_rows(
                 values["CUSTOMER_NAME"] = customer_name
 
             unmapped = [c for c in df_db.columns if c not in columns]
-            for i, col in enumerate(unmapped[:10], start=1):
-                values[f"ADHOC_INFO{i}"] = _to_str(row[col])
+            adhoc_slots = [f"ADHOC_INFO{i}" for i in range(1, 11)]
+            available_slots = [slot for slot in adhoc_slots if values[slot] is None]
+            for slot, col in zip(available_slots, unmapped):
+                values[slot] = _to_str(row[col])
 
 
             cur.execute(

--- a/tests/test_insert_pit_bid_rows_adhoc.py
+++ b/tests/test_insert_pit_bid_rows_adhoc.py
@@ -1,0 +1,61 @@
+import pandas as pd
+from app_utils import azure_sql
+
+
+def _fake_conn(captured):
+    class FakeCursor:
+        def execute(self, query, params):  # pragma: no cover - executed via call
+            captured["params"] = params
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    return FakeConn()
+
+
+def test_insert_pit_bid_rows_adhoc_sequential(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    df = pd.DataFrame(
+        {
+            "Lane ID": ["L1"],
+            "Foo": ["x"],
+            "Bar": ["y"],
+            "Baz": ["z"],
+        }
+    )
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
+    assert rows == 1
+    params = captured["params"]
+    assert params[2] == "L1"  # LANE_ID
+    assert params[14] == "x"  # ADHOC_INFO1
+    assert params[15] == "y"  # ADHOC_INFO2
+    assert params[16] == "z"  # ADHOC_INFO3
+    assert params[17] is None  # ADHOC_INFO4
+    assert params[23] is None  # ADHOC_INFO10
+
+
+def test_insert_pit_bid_rows_preserves_existing_adhoc(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    df = pd.DataFrame(
+        {
+            "Lane ID": ["L1"],
+            "ADHOC_INFO1": ["keep"],
+            "Extra": ["new"],
+        }
+    )
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
+    assert rows == 1
+    params = captured["params"]
+    assert params[14] == "keep"  # existing ADHOC_INFO1 preserved
+    assert params[15] == "new"  # ADHOC_INFO2 filled with extra column
+    assert params[16] is None  # ADHOC_INFO3 remains None
+    assert params[23] is None  # ADHOC_INFO10 remains None


### PR DESCRIPTION
## Summary
- ensure insert_pit_bid_rows assigns extra headers to the next free ADHOC_INFO slot without overwriting existing values
- cover ADHOC_INFO sequencing with new unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6893af85542c8333aeb520fd86027e4d