### PR TITLE
Use NamedTemporaryFile for CSV exports

### DIFF
--- a/app.py
+++ b/app.py
@@ -287,16 +287,21 @@ def main():
 
                     # Prepare CSV for download using current mappings
                     import tempfile
-                    tmp_csv = Path(tempfile.mkstemp(suffix=".csv")[1])
-                    mapped_df = save_mapped_csv(df, final_json, tmp_csv)
+
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".csv", delete=False
+                    ) as tmp:
+                        tmp_path = Path(tmp.name)
+                        mapped_df = save_mapped_csv(df, final_json, tmp_path)
+
                     rows = insert_pit_bid_rows(
                         mapped_df,
                         st.session_state["operation_code"],
                         st.session_state.get("customer_name"),
                         guid,
                     )
-                    csv_bytes = tmp_csv.read_bytes()
-                    tmp_csv.unlink()
+                    csv_bytes = tmp_path.read_bytes()
+                    tmp_path.unlink()
                     logs.append(
                         f"Inserted {rows} rows into RFP_OBJECT_DATA"
                     )

--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -250,8 +250,12 @@ def render(layer, idx: int) -> None:
             tpl_json = build_output_template(tpl_obj, st.session_state)
             import tempfile
 
-            tmp_path = Path(tempfile.mkstemp(suffix=".csv")[1])
-            save_mapped_csv(df, tpl_json, tmp_path)
+            with tempfile.NamedTemporaryFile(
+                suffix=".csv", delete=False
+            ) as tmp:
+                tmp_path = Path(tmp.name)
+                save_mapped_csv(df, tpl_json, tmp_path)
+
             csv_bytes = tmp_path.read_bytes()
             tmp_path.unlink()
             st.download_button(


### PR DESCRIPTION
## Summary
- replace mkstemp with NamedTemporaryFile in export and preview steps
- ensure temporary CSV files are cleaned up after reading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6893b4f88dbc8333ac67c616b9b13c67