### PR TITLE
Auto-map extra columns for pit bid inserts

### DIFF
--- a/tests/test_insert_pit_bid_rows_adhoc.py
+++ b/tests/test_insert_pit_bid_rows_adhoc.py
@@ -4,8 +4,17 @@ from app_utils import azure_sql
 
 def _fake_conn(captured):
     class FakeCursor:
-        def execute(self, query, params):  # pragma: no cover - executed via call
+        def __init__(self) -> None:
+            self.columns: list[str] = []
+
+        def execute(self, query, params=None):  # pragma: no cover - executed via call
+            if "INFORMATION_SCHEMA.COLUMNS" in query:
+                return self
             captured["params"] = params
+            return self
+
+        def fetchall(self):  # pragma: no cover - executed via call
+            return [(c,) for c in self.columns]
 
     class FakeConn:
         def cursor(self):


### PR DESCRIPTION
## Summary
- auto-detect additional columns in RFP_OBJECT_DATA and include them in PIT BID inserts
- add unit tests for new column mapping and ADHOC fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893c33a5da883338dc4daf626512bd7