### PR TITLE
Optimize pit-bid postprocess inserts with bulk executemany

### DIFF
--- a/tests/test_insert_pit_bid_rows_adhoc.py
+++ b/tests/test_insert_pit_bid_rows_adhoc.py
@@ -6,11 +6,16 @@ def _fake_conn(captured):
     class FakeCursor:
         def __init__(self) -> None:
             self.columns: list[str] = []
+            self.fast_executemany = False
 
         def execute(self, query, params=None):  # pragma: no cover - executed via call
             if "INFORMATION_SCHEMA.COLUMNS" in query:
                 return self
             captured["params"] = params
+            return self
+
+        def executemany(self, query, params):  # pragma: no cover - executed via call
+            captured["params"] = params[0] if params else None
             return self
 
         def fetchall(self):  # pragma: no cover - executed via call


### PR DESCRIPTION
## Summary
- Use pyodbc fast_executemany to bulk insert pit-bid rows into dbo.RFP_OBJECT_DATA for faster post-processing
- Update tests to accommodate bulk insert behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894b2606ed48333b52b8ccccb71b92b