### PR TITLE
Reorder PIT export flow and add SharePoint link

### DIFF
--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -97,7 +97,7 @@ def run_app(monkeypatch):
     def fake_runner(tpl, df, guid=None, *args):
         called["run"] = True
         called["guid"] = guid
-        return ["ok"], None
+        return ["ok"], {"p": 1}
 
     monkeypatch.setattr(
         "app_utils.postprocess_runner.run_postprocess_if_configured",
@@ -130,5 +130,6 @@ def test_postprocess_runner_called(monkeypatch):
     assert called.get("run") is True
     assert called.get("guid") is not None
     logs = state.get("export_logs")
-    assert logs[0] == "ok"
-    assert "Inserted" in logs[1]
+    assert "Inserted" in logs[0]
+    assert logs[1] == "ok"
+    assert state.get("postprocess_payload") == {"p": 1}


### PR DESCRIPTION
## Summary
- Insert pit-bid rows before triggering postprocess flow and keep payload
- Display confirmation message with link to client SharePoint destination
- Adjust wizard test for new export order and payload handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894c686cb308333b4875cb685f9adf1