### PR TITLE
Trigger postprocess after SQL insert

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -87,9 +87,9 @@ def main() -> None:
                 mapped_df, args.operation_code, args.customer_name
             )
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
-
-    # Trigger optional post-process actions
-    run_postprocess_if_configured(template, df)
+            run_postprocess_if_configured(
+                template, df, None, args.operation_code, args.customer_name
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Call `run_postprocess_if_configured` after SQL inserts with operation code and customer name
- Test that the CLI passes operation details to the post-process runner

## Testing
- `pytest tests/test_cli.py::test_cli_basic tests/test_cli.py::test_cli_csv_output tests/test_cli.py::test_cli_sql_insert tests/test_cli.py::test_cli_postprocess_receives_codes -q`


------
https://chatgpt.com/codex/tasks/task_b_6894cf3da63483338944da8077fcd3db