### PR TITLE
Use process guid in PIT BID payload

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -36,7 +36,7 @@ def run_postprocess(
 def run_postprocess_if_configured(
     template: Template,
     df: pd.DataFrame,
-    process_guid: str | None = None,
+    process_guid: str,
     operation_cd: str | None = None,
     customer_name: str | None = None,
 ) -> Tuple[List[str], Dict[str, Any] | None]:
@@ -49,6 +49,8 @@ def run_postprocess_if_configured(
         if template.template_name == "PIT BID":
             if not operation_cd:
                 raise ValueError("operation_cd required for PIT BID postprocess")
+            if not process_guid:
+                raise ValueError("process_guid required for PIT BID postprocess")
             payload = get_pit_url_payload(operation_cd)
             now = datetime.utcnow()
             stamp = customer_name or now.strftime("%H%M%S")
@@ -58,7 +60,7 @@ def run_postprocess_if_configured(
             if not in_data:
                 in_data.append({})
             in_data[0]["NEW_EXCEL_FILENAME"] = fname
-            payload["BID-Payload"] = True
+            payload["BID-Payload"] = process_guid
             logs.append(f"POST {template.postprocess.url}")
             if os.getenv("ENABLE_POSTPROCESS") == "1":
                 try:

--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,7 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any, Dict
+import uuid
 
 import pandas as pd
 
@@ -83,12 +84,13 @@ def main() -> None:
     if args.csv_output:
         mapped_df = save_mapped_csv(df, mapped, args.csv_output)
         if args.operation_code and template.template_name == "PIT BID":
+            guid = str(uuid.uuid4())
             rows = azure_sql.insert_pit_bid_rows(
-                mapped_df, args.operation_code, args.customer_name
+                mapped_df, args.operation_code, args.customer_name, guid
             )
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
             run_postprocess_if_configured(
-                template, df, None, args.operation_code, args.customer_name
+                template, df, guid, args.operation_code, args.customer_name
             )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,10 +51,11 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
 
     captured: dict[str, object] = {}
 
-    def fake_insert(df, op, cust):
+    def fake_insert(df, op, cust, guid):
         captured['cols'] = list(df.columns)
         captured['op'] = op
         captured['cust'] = cust
+        captured['guid'] = guid
         return len(df)
 
     monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
@@ -77,6 +78,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
     assert captured['op'] == 'OP'
     assert captured['cust'] == 'Cust'
     assert 'Lane ID' in captured['cols']
+    assert captured['guid']
 
 
 def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path):
@@ -86,14 +88,15 @@ def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path):
     out_json = tmp_path / 'out.json'
     out_csv = tmp_path / 'out.csv'
 
-    def fake_insert(df, op, cust):
+    def fake_insert(df, op, cust, guid):
         return len(df)
 
     captured: dict[str, object] = {}
 
-    def fake_postprocess(tpl_obj, df, guid, op_cd, cust_name):
+    def fake_postprocess(tpl_obj, df, process_guid, op_cd, cust_name):
         captured['op'] = op_cd
         captured['cust'] = cust_name
+        captured['guid'] = process_guid
         return [], None
 
     monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
@@ -114,4 +117,5 @@ def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path):
     cli.main()
     assert captured['op'] == 'OP'
     assert captured['cust'] == 'Cust'
+    assert captured['guid']
 

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -90,13 +90,13 @@ def run_app(monkeypatch):
     )
     monkeypatch.setattr("app_utils.azure_sql.fetch_customers", lambda scac: [])
     monkeypatch.setattr(
-        "app_utils.azure_sql.insert_pit_bid_rows", lambda df, op, cust, guid=None: len(df)
+        "app_utils.azure_sql.insert_pit_bid_rows", lambda df, op, cust, guid: len(df)
     )
     called: dict[str, object] = {}
 
-    def fake_runner(tpl, df, guid=None, *args):
+    def fake_runner(tpl, df, process_guid, *args):
         called["run"] = True
-        called["guid"] = guid
+        called["guid"] = process_guid
         return ["ok"], {"p": 1}
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- require a process GUID for `run_postprocess_if_configured` and include it in PIT BID payloads
- generate a process GUID in CLI and forward it to insert and postprocess helpers
- expand tests to pass and validate the process GUID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894d4e5736083339927c7609613fbc5