### PR TITLE
Display postprocess payload

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,6 +330,9 @@ def main():
                 )
             for line in st.session_state.get("export_logs", []):
                 st.write(line)
+            if st.session_state.get("postprocess_payload") is not None:
+                st.write(template_obj.postprocess.url)
+                st.json(st.session_state.get("postprocess_payload"))
             st.json(st.session_state.get("final_json"))
             csv_data = st.session_state.get("mapped_csv")
             if csv_data:


### PR DESCRIPTION
## Summary
- Show postprocess endpoint and payload after export runs
- Track Streamlit json calls in tests and assert payload is rendered

## Testing
- `pytest tests/test_wizard_postprocess.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6894e0e7d15c8333a4e5516f625446dd