### PR TITLE
Log PIT BID payload regardless of postprocess flag

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -63,8 +63,8 @@ def run_postprocess_if_configured(
             in_data[0]["NEW_EXCEL_FILENAME"] = fname
             payload["BID-Payload"] = process_guid
             logs.append(f"POST {template.postprocess.url}")
+            logs.append(f"Payload: {json.dumps(payload)}")
             if os.getenv("ENABLE_POSTPROCESS") == "1":
-                logs.append(f"Payload: {json.dumps(payload)}")
                 try:
                     import requests  # type: ignore
 


### PR DESCRIPTION
## Summary
- Log PIT BID postprocess payload before ENABLE_POSTPROCESS check
- Return payload to callers for display
- Test that PIT BID logs always include payload, even when disabled

## Testing
- `pytest tests/test_postprocess_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6894e0d95ff483338ed3906f0181b81e