### PR TITLE
Ensure Power Automate post-processing flag is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ new template JSON with those mappings and any resolved formulas.
 
 Templates may include an optional `postprocess` block. When present and
 `ENABLE_POSTPROCESS=1` is set, the mapped rows are sent as a POST request to the
-configured URL. See `docs/template_spec.md` for details.
+configured URL. Set this flag in environments where a Power Automate flow
+should run (e.g., `export ENABLE_POSTPROCESS=1` or launch via
+`start_postprocess.py`). See `docs/template_spec.md` for details.

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -53,8 +53,8 @@ def run_postprocess_if_configured(
             if not process_guid:
                 raise ValueError("process_guid required for PIT BID postprocess")
             logs.append(f"POST {template.postprocess.url}")
-            logs.append(f"Payload: {json.dumps(payload)}")
-            if os.getenv("ENABLE_POSTPROCESS") == "1":
+            payload = None
+            try:
                 payload = get_pit_url_payload(operation_cd)
                 now = datetime.utcnow()
                 stamp = customer_name or now.strftime("%H%M%S")
@@ -66,7 +66,9 @@ def run_postprocess_if_configured(
                 in_data[0]["NEW_EXCEL_FILENAME"] = fname
                 payload["BID-Payload"] = process_guid
                 logs.append(f"Payload: {json.dumps(payload)}")
-
+            except RuntimeError as err:  # pragma: no cover - exercised in integration
+                logs.append(f"Payload error: {err}")
+            if payload is not None and os.getenv("ENABLE_POSTPROCESS") == "1":
                 try:
                     import requests  # type: ignore
 

--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -157,8 +157,9 @@ At run-time the user builds an expression; the engine stores its resolution:
 ```
 
 When present, the mapped rows are sent as a JSON array via HTTP `POST` to the
-specified URL. Set the environment variable `ENABLE_POSTPROCESS=1` to allow
-the request during execution.
+specified URL. Set the environment variable `ENABLE_POSTPROCESS=1` to allow the
+request during execution. Without this flag the Power Automate flow will not
+be invoked.
 
 After all layers are confirmed the wizard enters a **Run Export** step. If a
 `postprocess` block exists, `run_postprocess_if_configured` posts the mapped

--- a/start_postprocess.py
+++ b/start_postprocess.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Streamlit startup script that enables post-processing."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    """Launch the Streamlit app with post-processing enabled."""
+    os.environ["ENABLE_POSTPROCESS"] = "1"
+    subprocess.run(["streamlit", "run", "app.py", *sys.argv[1:]], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_postprocess.py` helper to launch Streamlit with post-processing enabled
- document `ENABLE_POSTPROCESS` flag in README and template spec
- build PIT BID payload before sending and guard post-process by flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894e36b12c88333b6a1752401f679f4