### PR TITLE
Print postprocess payload in CLI

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -53,9 +53,9 @@ def run_postprocess_if_configured(
             if not process_guid:
                 raise ValueError("process_guid required for PIT BID postprocess")
             logs.append(f"POST {template.postprocess.url}")
+            payload = get_pit_url_payload(operation_cd)
             logs.append(f"Payload: {json.dumps(payload)}")
             if os.getenv("ENABLE_POSTPROCESS") == "1":
-                payload = get_pit_url_payload(operation_cd)
                 now = datetime.utcnow()
                 stamp = customer_name or now.strftime("%H%M%S")
                 fname = f"{operation_cd} - {now.strftime('%Y%m%d')} PIT12wk - {stamp} BID.xlsm"

--- a/cli.py
+++ b/cli.py
@@ -101,7 +101,7 @@ def main() -> None:
             )
             for line in logs_post:
                 print(line)
-            if payload and os.getenv("DEBUG_POSTPROCESS") == "1":
+            if payload is not None:
                 print(json.dumps(payload, indent=2))
 
 


### PR DESCRIPTION
## Summary
- Always print postprocess logs and payload in the CLI, including endpoint URL.
- Generate PIT BID payload for logging even when postprocess is disabled.
- Expand CLI tests to assert POST log lines and payload output.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894e368cde48333bcee719344b5c845