### PR TITLE
Raise errors when PIT BID payload fetch fails

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -55,20 +55,21 @@ def run_postprocess_if_configured(
             logs.append(f"POST {template.postprocess.url}")
             try:
                 payload = get_pit_url_payload(operation_cd)
-                logs.append(f"Payload: {json.dumps(payload)}")
-                if os.getenv("ENABLE_POSTPROCESS") == "1":
-                    now = datetime.utcnow()
-                    stamp = customer_name or now.strftime("%H%M%S")
-                    fname = f"{operation_cd} - {now.strftime('%Y%m%d')} PIT12wk - {stamp} BID.xlsm"
-                    item = payload.setdefault("item", {})
-                    in_data = item.setdefault("In_dtInputData", [{}])
-                    if not in_data:
-                        in_data.append({})
-                    in_data[0]["NEW_EXCEL_FILENAME"] = fname
-                    payload["BID-Payload"] = process_guid
-                    logs.append(f"Payload: {json.dumps(payload)}")
             except RuntimeError as err:  # pragma: no cover - exercised in integration
                 logs.append(f"Payload error: {err}")
+                raise
+            logs.append(f"Payload: {json.dumps(payload)}")
+            if os.getenv("ENABLE_POSTPROCESS") == "1":
+                now = datetime.utcnow()
+                stamp = customer_name or now.strftime("%H%M%S")
+                fname = f"{operation_cd} - {now.strftime('%Y%m%d')} PIT12wk - {stamp} BID.xlsm"
+                item = payload.setdefault("item", {})
+                in_data = item.setdefault("In_dtInputData", [{}])
+                if not in_data:
+                    in_data.append({})
+                in_data[0]["NEW_EXCEL_FILENAME"] = fname
+                payload["BID-Payload"] = process_guid
+                logs.append(f"Payload: {json.dumps(payload)}")
             if payload is not None and os.getenv("ENABLE_POSTPROCESS") == "1":
                 try:
                     import requests  # type: ignore

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -181,13 +181,11 @@ def test_pit_bid_null_payload_logged(monkeypatch):
         'layers': [{'type': 'header', 'fields': [{'key': 'A'}]}],
         'postprocess': {'url': 'https://example.com/post'},
     })
-    logs, payload = run_postprocess_if_configured(
-        tpl,
-        pd.DataFrame({'A': [1]}),
-        'guid',
-        operation_cd='OP',
-    )
-    assert payload is None
-    assert any(line == 'Payload error: null payload' for line in logs)
-    assert logs[-1] == 'Postprocess disabled'
+    with pytest.raises(RuntimeError, match='null payload'):
+        run_postprocess_if_configured(
+            tpl,
+            pd.DataFrame({'A': [1]}),
+            'guid',
+            operation_cd='OP',
+        )
 


### PR DESCRIPTION
## Summary
- log PIT BID payload then re-raise fetch errors so downstream logic notices
- adjust PIT BID postprocess test to expect RuntimeError on payload failure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894e876f8e48333bc2ff62ec86166db