### PR TITLE
Flatten PIT BID postprocess payload key

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -63,8 +63,7 @@ def run_postprocess_if_configured(
         now = datetime.utcnow()
         stamp = customer_name or now.strftime("%H%M%S")
         fname = f"{operation_cd} - {now.strftime('%Y%m%d')} PIT12wk - {stamp} BID.xlsm"
-        item = payload.setdefault("item", {})
-        in_data = item.setdefault("In_dtInputData", [{}])
+        in_data = payload.setdefault("item/In_dtInputData", [{}])
         if not in_data:
             in_data.append({})
         in_data[0]["NEW_EXCEL_FILENAME"] = fname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from dotenv import load_dotenv
+try:  # pragma: no cover - tiny shim when python-dotenv missing
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - fallback for minimal test env
+    def load_dotenv() -> None:
+        """Stub when ``python-dotenv`` is unavailable."""
+        return None
 
 
 @pytest.fixture

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -79,7 +79,7 @@ def test_if_configured_applies_header_mappings(load_env, monkeypatch):
 
 
 def test_pit_bid_posts_payload(load_env, monkeypatch):
-    payload = {"item": {"In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}]}}
+    payload = {"item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}]}
     monkeypatch.setattr(
         'app_utils.postprocess_runner.get_pit_url_payload',
         lambda op_cd, week_ct=12: payload,
@@ -109,7 +109,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
         operation_cd='OP',
         customer_name='Cust',
     )
-    assert returned['item']['In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == (
+    assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == (
         'OP - 20240102 PIT12wk - Cust BID.xlsm'
     )
     assert returned['BID-Payload'] == "guid"
@@ -120,7 +120,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
 
 
 def test_pit_bid_logs_payload_when_disabled(monkeypatch):
-    payload = {"item": {"In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}]}}
+    payload = {"item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}]}
     monkeypatch.setattr(
         'app_utils.postprocess_runner.get_pit_url_payload',
         lambda op_cd, week_ct=12: payload,
@@ -153,7 +153,7 @@ def test_pit_bid_logs_payload_when_disabled(monkeypatch):
     assert any(line.startswith('Payload:') for line in logs)
     assert logs[-1] == 'Postprocess disabled'
     assert 'url' not in called
-    assert returned['item']['In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == (
+    assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == (
         'OP - 20240102 PIT12wk - Cust BID.xlsm'
     )
     assert returned['BID-Payload'] == 'guid'

--- a/tests/test_reset_button.py
+++ b/tests/test_reset_button.py
@@ -44,6 +44,7 @@ class DummyStreamlit:
         self.session_state = {}
         self.sidebar = DummySidebar(self)
         self.rerun_called = False
+        self.secrets = {}
     def set_page_config(self, *a, **k):
         pass
     def title(self, *a, **k):

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -47,6 +47,7 @@ class DummyStreamlit:
         self.session_state = {}
         self.sidebar = DummySidebar(self)
         self.json_calls: list[object] = []
+        self.secrets = {}
     def set_page_config(self, *a, **k):
         pass
     def title(self, *a, **k):


### PR DESCRIPTION
## Summary
- store PIT BID filename under `item/In_dtInputData` instead of nested `item`
- update tests for new payload shape and provide dotenv/Streamlit stubs for test harness

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, json
import app_utils.azure_sql as az
from pathlib import Path

az.insert_pit_bid_rows = lambda df, op, cust, guid: len(df)
az.get_pit_url_payload = lambda op_cd, week_ct=12: {}

import cli
sys.argv = ['cli.py', 'templates/pit-bid.json', 'tests/fixtures/simple.csv', 'out.json', '--csv-output', 'out.csv', '--operation-code', 'OP', '--customer-name', 'Cust']
cli.main()
PY`


------
https://chatgpt.com/codex/tasks/task_b_68950b8244dc8333bc84ee9b30f807fc