### PR TITLE
Adjust PIT BID filename format

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -62,11 +62,11 @@ def run_postprocess_if_configured(
         logs.append(f"Payload: {json.dumps(payload)}")
         now = datetime.utcnow()
         stamp = customer_name or now.strftime("%H%M%S")
-        fname = f"{operation_cd} - {now.strftime('%Y%m%d')} PIT12wk - {stamp} BID.xlsm"
-        in_data = payload.setdefault("item/In_dtInputData", [{}])
-        if not in_data:
-            in_data.append({})
-        in_data[0]["NEW_EXCEL_FILENAME"] = fname
+        fname = f"{operation_cd} - BID - {stamp} BID.xlsm"
+        payload.setdefault("item/In_dtInputData", [{}])
+        if not payload["item/In_dtInputData"]:
+            payload["item/In_dtInputData"].append({})
+        payload["item/In_dtInputData"][0]["NEW_EXCEL_FILENAME"] = fname
         payload["BID-Payload"] = process_guid
         logs.append(f"Payload: {json.dumps(payload)}")
         if os.getenv("ENABLE_POSTPROCESS") == "1":


### PR DESCRIPTION
## Summary
- format PIT BID postprocess output as `{operation_cd} - BID - {stamp} BID.xlsm`
- ensure the payload's `NEW_EXCEL_FILENAME` is updated in-place
- extend tests to verify logged payload uses new filename with no duplicates

## Testing
- `pytest tests/test_postprocess_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68950d8482748333a82e13f7cb77cfcc