### PR TITLE
Warn when post-process flag missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ new template JSON with those mappings and any resolved formulas.
 
 ## Post-processing
 
-Templates may include an optional `postprocess` block. When present and
-`ENABLE_POSTPROCESS=1` is set, the mapped rows are sent as a POST request to the
-configured URL. Set this flag in a `.env` file or add it to `.streamlit/secrets.toml`.
+Templates may include an optional `postprocess` block. To trigger the Power
+Automate flow for those templates, set `ENABLE_POSTPROCESS=1`; otherwise the
+mapped rows are never sent to the configured URL. Set this flag in a `.env`
+file or add it to `.streamlit/secrets.toml`.
 
 ```bash
 export ENABLE_POSTPROCESS=1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
 import pytest
 try:  # pragma: no cover - tiny shim when python-dotenv missing
     from dotenv import load_dotenv  # type: ignore
@@ -8,8 +10,19 @@ except Exception:  # pragma: no cover - fallback for minimal test env
         """Stub when ``python-dotenv`` is unavailable."""
         return None
 
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - safety for older Python
+    tomllib = None  # type: ignore
+
 
 @pytest.fixture
 def load_env() -> None:
-    """Load environment variables from a .env file for tests."""
+    """Load environment variables from `.env` and secrets for tests."""
     load_dotenv()
+    secrets_path = Path(".streamlit/secrets.toml")
+    if tomllib and secrets_path.exists():
+        with secrets_path.open("rb") as fh:
+            secrets = tomllib.load(fh)
+        for key, value in secrets.items():
+            os.environ.setdefault(key, str(value))

--- a/tests/test_postprocess_flag_warning.py
+++ b/tests/test_postprocess_flag_warning.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from app import warn_if_postprocess_missing
+
+
+def test_warn_if_postprocess_missing(monkeypatch) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr(st, "info", lambda msg: messages.append(msg))
+    monkeypatch.setenv("ENABLE_POSTPROCESS", "0")
+    warn_if_postprocess_missing()
+    assert messages and "ENABLE_POSTPROCESS=1" in messages[0]


### PR DESCRIPTION
## Summary
- document that ENABLE_POSTPROCESS=1 is required to trigger the Power Automate flow
- load ENABLE_POSTPROCESS from secrets and warn when it is disabled
- load secrets in tests and add coverage for post-process flag warning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68951187daa483339c48f22dc2400226