### PR TITLE
Ensure CLI exports always print postprocess payload

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -102,7 +102,6 @@ def main() -> None:
             for line in logs_post:
                 print(line)
             if payload is not None:
-                # Always show the post-process payload for visibility
                 print(json.dumps(payload, indent=2))
 
 


### PR DESCRIPTION
## Summary
- Always print the post-process payload in the CLI when available.
- Restore inadvertent changes to mapping suggestions data.

## Testing
- `pytest -q`
- Manual `python cli.py templates/pit-bid.json <temp csv> <temp out>` with monkeypatched postprocess utilities to show HTTP endpoint and JSON payload

------
https://chatgpt.com/codex/tasks/task_b_6895142a63bc833394cea1a9a3b4b646