### PR TITLE
feat: expose postprocess flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ try:
     secret_flag = st.secrets.get("ENABLE_POSTPROCESS", "0")
 except Exception:  # pragma: no cover - secrets file absent
     secret_flag = "0"
-os.environ.setdefault("ENABLE_POSTPROCESS", secret_flag)
+os.environ["ENABLE_POSTPROCESS"] = os.getenv("ENABLE_POSTPROCESS", secret_flag)
 
 
 def warn_if_postprocess_missing() -> None:

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -72,7 +72,8 @@ def run_postprocess_if_configured(
         else:
             logs.append("Missing BID-Payload in payload")
         logs.append(f"Payload: {json.dumps(payload)}")
-        if os.getenv("ENABLE_POSTPROCESS") == "1":
+        flag = os.getenv("ENABLE_POSTPROCESS", "0")
+        if flag == "1":
             try:
                 import requests  # type: ignore
 
@@ -91,7 +92,7 @@ def run_postprocess_if_configured(
             else:
                 logs.append("Done")
         else:
-            logs.append("Postprocess disabled")
+            logs.append(f"Postprocess disabled (ENABLE_POSTPROCESS={flag})")
     else:
         run_postprocess(template.postprocess, df, logs)
     return logs, payload

--- a/cli.py
+++ b/cli.py
@@ -6,6 +6,19 @@ from typing import Any, Dict
 import uuid
 
 import pandas as pd
+import streamlit as st
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv() -> None:
+        return None
+
+load_dotenv()
+try:
+    secret_flag = st.secrets.get("ENABLE_POSTPROCESS", "0")
+except Exception:  # pragma: no cover - secrets file absent
+    secret_flag = "0"
+os.environ["ENABLE_POSTPROCESS"] = os.getenv("ENABLE_POSTPROCESS", secret_flag)
 
 from schemas.template_v2 import Template
 from app_utils.excel_utils import excel_to_json, save_mapped_csv

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -173,7 +173,7 @@ def test_pit_bid_logs_payload_when_disabled(monkeypatch):
     logged_payload = json.loads(payload_logs[-1].split('Payload: ')[1])
     assert logged_payload['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert logged_payload['BID-Payload'] == 'guid'
-    assert logs[-1] == 'Postprocess disabled'
+    assert logs[-1] == 'Postprocess disabled (ENABLE_POSTPROCESS=0)'
     assert 'url' not in called
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == 'guid'


### PR DESCRIPTION
## Summary
- load .env and propagate ENABLE_POSTPROCESS default from Streamlit secrets in app and CLI
- log resolved postprocess flag in runner and surface flag value when disabled
- adjust postprocess tests for updated logging

## Testing
- `pytest -q`
- `python - <<'PY'
import os, pandas as pd, types, sys
from schemas.template_v2 import Template
from app_utils import postprocess_runner

def fake_payload(op_cd, week_ct=12):
    return {"item/In_dtInputData": [{}], "BID-Payload": ""}
postprocess_runner.get_pit_url_payload = fake_payload

tpl = Template.model_validate({'template_name': 'PIT BID','layers': [{'type': 'header', 'fields': [{'key': 'A'}]}],'postprocess': {'url': 'https://example.com/post'}})
df = pd.DataFrame({'A': [1]})
os.environ.pop('ENABLE_POSTPROCESS', None)
logs1, _ = postprocess_runner.run_postprocess_if_configured(tpl, df, 'guid', operation_cd='OP', customer_name='Cust')
print('Case1:', logs1[-1])
os.environ['ENABLE_POSTPROCESS'] = '1'
sys.modules['requests'] = types.SimpleNamespace(post=lambda url, json=None, timeout=10: types.SimpleNamespace(status_code=200, text='ok', raise_for_status=lambda: None))
logs2, _ = postprocess_runner.run_postprocess_if_configured(tpl, df, 'guid', operation_cd='OP', customer_name='Cust')
print('Case2:', logs2[-1])
PY`


------
https://chatgpt.com/codex/tasks/task_b_689517bb72cc83338d41d730499a89cd