### PR TITLE
Return postprocess payload even when disabled

### DIFF
--- a/app.py
+++ b/app.py
@@ -350,10 +350,9 @@ def main():
                 )
             for line in st.session_state.get("export_logs", []):
                 st.write(line)
-            if st.session_state.get("postprocess_payload"):
-                if template_obj.postprocess:
-                    st.write(template_obj.postprocess.url)
-                st.json(st.session_state["postprocess_payload"])
+            if template_obj.postprocess:
+                st.write(template_obj.postprocess.url)
+            st.json(st.session_state.get("postprocess_payload"))
             st.json(st.session_state.get("final_json"))
             csv_data = st.session_state.get("mapped_csv")
             if csv_data:

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -40,11 +40,11 @@ def run_postprocess_if_configured(
     process_guid: str,
     operation_cd: str | None = None,
     customer_name: str | None = None,
-) -> Tuple[List[str], Dict[str, Any] | None]:
+) -> Tuple[List[str], Dict[str, Any] | List[Dict[str, Any]] | None]:
     """Run optional postprocess hooks based on ``template``."""
 
     logs: List[str] = []
-    payload: Dict[str, Any] | None = None
+    payload: Dict[str, Any] | List[Dict[str, Any]] | None = None
     df = apply_header_mappings(df, template)
     if not template.postprocess:
         return logs, payload
@@ -94,5 +94,6 @@ def run_postprocess_if_configured(
         else:
             logs.append(f"Postprocess disabled (ENABLE_POSTPROCESS={flag})")
     else:
+        payload = df.to_dict(orient="records")
         run_postprocess(template.postprocess, df, logs)
     return logs, payload

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -49,7 +49,7 @@ def test_if_configured_helper(load_env, monkeypatch):
     logs, payload = run_postprocess_if_configured(tpl, pd.DataFrame(), "guid")
     assert called.get('run') is True
     assert isinstance(logs, list)
-    assert payload is None
+    assert payload == []
 
 
 def test_if_configured_applies_header_mappings(load_env, monkeypatch):


### PR DESCRIPTION
## Summary
- Always return payload from `run_postprocess_if_configured` by capturing DataFrame records before triggering optional HTTP call
- Always show postprocess URL and payload in Streamlit export step
- Adjust unit tests for new payload behavior

## Testing
- `pytest`
- `ENABLE_POSTPROCESS=0` run_postprocess_if_configured sample
- `ENABLE_POSTPROCESS=1` run_postprocess_if_configured sample


------
https://chatgpt.com/codex/tasks/task_b_68951a0633548333b6a97c08e104fe49