### PR TITLE
Remove postprocess feature flag

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,11 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
     monkeypatch.setattr(
         'app_utils.postprocess_runner.get_pit_url_payload', lambda op_cd: {}
     )
+    monkeypatch.setattr(
+        cli,
+        'run_postprocess_if_configured',
+        lambda tpl_obj, df, guid, operation_code=None, customer_name=None: ([], None),
+    )
     monkeypatch.setattr(sys, 'argv', [
         'cli.py',
         str(tpl),


### PR DESCRIPTION
## Summary
- Always send POST requests in `run_postprocess` and `run_postprocess_if_configured` without checking `ENABLE_POSTPROCESS`
- Remove obsolete flag handling and associated tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68951cc70f5c83339a931ca96c19d6ca