### PR TITLE
Remove embedded postprocess flag from CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,12 +1,10 @@
 import argparse
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict
 import uuid
 
 import pandas as pd
-import streamlit as st
 try:
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover - optional dependency
@@ -14,11 +12,6 @@ except Exception:  # pragma: no cover - optional dependency
         return None
 
 load_dotenv()
-try:
-    secret_flag = st.secrets.get("ENABLE_POSTPROCESS", "0")
-except Exception:  # pragma: no cover - secrets file absent
-    secret_flag = "0"
-os.environ["ENABLE_POSTPROCESS"] = os.getenv("ENABLE_POSTPROCESS", secret_flag)
 
 from schemas.template_v2 import Template
 from app_utils.excel_utils import excel_to_json, save_mapped_csv


### PR DESCRIPTION
## Summary
- drop Streamlit secrets use and stop setting ENABLE_POSTPROCESS in cli
- keep CLI printing post-process logs and payloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68951fcb04b08333af616649c88a8ce9