### PR TITLE
docs: explain automatic postprocess trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,16 @@ new template JSON with those mappings and any resolved formulas.
 
 ## Post-processing
 
-Set `ENABLE_POSTPROCESS=1` (via `.env`, `secrets.toml`, or shell) to activate
-PIT BID's Power Automate trigger.
-
-Templates may include an optional `postprocess` block; without the flag, mapped
-rows are never sent to the configured URL.
+Templates may include an optional `postprocess` block. Any template with a
+`postprocess` block will automatically trigger an HTTP `POST` of the mapped
+rows to the configured URL after export.
 
 Example launch:
 
 ```bash
-ENABLE_POSTPROCESS=1 streamlit run app.py
+streamlit run app.py
 # or
 python start_postprocess.py
 ```
 
-Add this variable to your production hosting configuration so Power Automate
-flows run; without it, post-processing is skipped. See `docs/template_spec.md`
-for details.
+See `docs/template_spec.md` for details.

--- a/docs/template_spec.md
+++ b/docs/template_spec.md
@@ -157,9 +157,8 @@ At run-time the user builds an expression; the engine stores its resolution:
 ```
 
 When present, the mapped rows are sent as a JSON array via HTTP `POST` to the
-specified URL. Set the environment variable `ENABLE_POSTPROCESS=1` to allow the
-request during execution. Without this flag the Power Automate flow will not
-be invoked.
+specified URL after export. Any template with a `postprocess` block will
+automatically trigger this `POST` once the export completes.
 
 After all layers are confirmed the wizard enters a **Run Export** step. If a
 `postprocess` block exists, `run_postprocess_if_configured` posts the mapped


### PR DESCRIPTION
## Summary
- clarify that templates with a `postprocess` block auto-send mapped rows via HTTP POST after export
- remove `ENABLE_POSTPROCESS` flag references from README and spec

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689520dbd3b883339dce9d6859bec322