### PR TITLE
Add template GUID support and propagate through templates

### DIFF
--- a/app_utils/template_builder.py
+++ b/app_utils/template_builder.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple
 import json
 import os
 import re
+import uuid
 import pandas as pd
 from schemas.template_v2 import Template, LookupLayer, ComputedLayer
 
@@ -21,11 +22,13 @@ def build_template(
     template_name: str,
     layers: List[Dict],
     postprocess: Dict | None = None,
+    template_guid: str | None = None,
 ) -> Dict:
     """Return a validated template structure with arbitrary layers."""
     tpl = {"template_name": template_name, "layers": layers}
     if postprocess:
         tpl["postprocess"] = postprocess
+    tpl["template_guid"] = template_guid or str(uuid.uuid4())
     Template.model_validate(tpl)
     return tpl
 
@@ -56,6 +59,7 @@ def save_template_file(tpl: Dict, directory: str = "templates") -> str:
     safe = slugify(tpl["template_name"])
     os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, f"{safe}.json")
+    tpl.setdefault("template_guid", str(uuid.uuid4()))
     with open(path, "w") as f:
         json.dump(tpl, f, indent=2)
     return safe

--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -16,7 +16,6 @@ from app_utils.template_builder import (
     build_template,
     load_template_json,
     save_template_file,
-    slugify,
     apply_field_choices,
     gpt_field_suggestions,
 )
@@ -213,9 +212,7 @@ def edit_template(filename: str, data: dict) -> None:
                     else:
                         obj["postprocess"] = post_obj
                     Template.model_validate(obj)
-                    safe = slugify(obj["template_name"])
-                    with open(os.path.join("templates", f"{safe}.json"), "w") as f:
-                        json.dump(obj, f, indent=2)
+                    safe = save_template_file(obj)
                     if safe + ".json" != filename:
                         os.remove(os.path.join("templates", filename))
                     st.success("Template saved")

--- a/schemas/template_v2.py
+++ b/schemas/template_v2.py
@@ -25,6 +25,7 @@ from pydantic import (
     HttpUrl,
 )
 from typing import List, Literal, Optional, Dict, Any
+from uuid import UUID
 
 
 class FieldSpec(BaseModel):
@@ -76,6 +77,9 @@ Layer = HeaderLayer | LookupLayer | ComputedLayer
 
 
 class Template(BaseModel):
+    template_guid: Optional[str] = Field(
+        default=None, description="Unique identifier for this template"
+    )
     template_name: str
     layers: List[Layer]
     postprocess: Optional[PostprocessSpec] = None
@@ -84,6 +88,14 @@ class Template(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     # Pydantic-v2 syle validator
+    @field_validator("template_guid")
+    @classmethod
+    def _valid_guid(cls, v: Optional[str]):
+        if v is None:
+            return v
+        UUID(v)
+        return v
+
     @field_validator("layers")
     @classmethod
     def _non_empty_layers(cls, v: List[Layer]):

--- a/templates/pit-bid.json
+++ b/templates/pit-bid.json
@@ -1,5 +1,6 @@
 {
   "template_name": "PIT BID",
+  "template_guid": "26432804-560c-4b52-9040-529689e83375",
   "layers": [
     {
       "type": "header",

--- a/templates/standard-coa.json
+++ b/templates/standard-coa.json
@@ -1,5 +1,6 @@
 {
   "template_name": "Standard COA",
+  "template_guid": "ce70c208-8b05-4485-b05c-848a3dc938d4",
   "fields": [
     {
       "key": "GL_ID",

--- a/templates/standard-fm-coa.json
+++ b/templates/standard-fm-coa.json
@@ -1,5 +1,6 @@
 {
   "template_name": "Standard COA",
+  "template_guid": "3a96d44e-b82e-41cb-afed-8c8a1b61468c",
 
   "fields": [
     { "key": "GL_ID",        "type": "string" },

--- a/templates/user-defined-demo.json
+++ b/templates/user-defined-demo.json
@@ -1,5 +1,6 @@
 {
   "template_name": "User Defined Demo",
+  "template_guid": "ee2705fc-ccc3-4eba-b863-f490e5f8f90c",
   "layers": [
     {
       "type": "header",

--- a/tests/fixtures/simple-template.json
+++ b/tests/fixtures/simple-template.json
@@ -1,5 +1,6 @@
 {
   "template_name": "simple-template",
+  "template_guid": "1d448372-6dfc-49da-970d-435e1ecf00b5",
   "layers": [
     {
       "type": "header",

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -7,7 +7,9 @@ from app_utils.mapping.exporter import build_output_template
 
 def load_sample(name: str) -> Template:
     txt = Path("templates") / f"{name}.json"
-    return Template.model_validate(json.loads(txt.read_text()))
+    tpl = Template.model_validate(json.loads(txt.read_text()))
+    assert tpl.template_guid
+    return tpl
 
 
 def test_expressions_in_output():

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -26,6 +26,7 @@ def test_build_header_template_valid():
     cols = ["A", "B"]
     required = {"A": True, "B": False}
     tpl = build_header_template("demo", cols, required, None)
+    assert tpl.get("template_guid")
     Template.model_validate(tpl)
 
 
@@ -35,6 +36,7 @@ def test_build_header_template_with_postprocess():
     post = {"url": "https://example.com"}
     tpl = build_header_template("demo", cols, required, post)
     assert tpl["postprocess"] == post
+    assert tpl.get("template_guid")
     Template.model_validate(tpl)
 
 
@@ -42,13 +44,18 @@ def test_load_template_json_valid():
     with open("tests/fixtures/simple-template.json") as f:
         tpl = load_template_json(f)
     assert tpl["template_name"] == "simple-template"
+    assert tpl.get("template_guid")
 
 
 def test_save_template_file(tmp_path):
     tpl = {"template_name": "demo*temp", "layers": []}
     name = save_template_file(tpl, directory=tmp_path)
     assert name == "demo-temp"
-    assert (tmp_path / f"{name}.json").exists()
+    assert tpl.get("template_guid")
+    path = tmp_path / f"{name}.json"
+    assert path.exists()
+    saved = json.loads(path.read_text())
+    assert saved.get("template_guid") == tpl["template_guid"]
 
 
 def test_slugify_examples():
@@ -212,6 +219,7 @@ def test_build_lookup_and_computed_layers():
     lookup = build_lookup_layer("SRC", "DEST", "dict", sheet="Sheet1")
     computed = build_computed_layer("TOTAL", "df['A'] + df['B']")
     tpl = build_template("demo", [lookup, computed])
+    assert tpl.get("template_guid")
     Template.model_validate(tpl)
 
 
@@ -221,6 +229,7 @@ def test_build_template_with_header_and_extra_layers():
     comp = build_computed_layer("TOTAL", "df['A']")
     layers = [header["layers"][0], lookup, comp]
     tpl = build_template("demo", layers)
+    assert tpl.get("template_guid")
     Template.model_validate(tpl)
 
 
@@ -241,6 +250,7 @@ def test_build_template_multiple_extra_layers():
     c1 = build_computed_layer("TOTAL", "df['A'] + df['B']")
     layers = [header["layers"][0], l1, l2, c1]
     tpl = build_template("demo", layers)
+    assert tpl.get("template_guid")
     Template.model_validate(tpl)
 
 

--- a/tests/test_template_manager_ui.py
+++ b/tests/test_template_manager_ui.py
@@ -192,9 +192,13 @@ def test_postprocess_passed_to_builder(monkeypatch):
 
     captured = {}
 
-    def fake_builder(name, layers, post=None):
+    def fake_builder(name, layers, post=None, template_guid=None):
         captured["post"] = post
-        return {"template_name": name, "layers": layers}
+        return {
+            "template_name": name,
+            "layers": layers,
+            "template_guid": template_guid or "guid",
+        }
 
     dummy = run_manager(
         monkeypatch,


### PR DESCRIPTION
## Summary
- add optional `template_guid` to schema with UUID validation
- generate and persist GUIDs in template builder and manager
- update existing templates, fixtures, and tests for `template_guid`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68961a50eb4483339b5609e626964c91