### PR TITLE
Add helper to log mapping processes

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -278,3 +278,15 @@ def insert_pit_bid_rows(
                 rows,
             )
     return len(rows)
+
+
+def log_mapping_process(process_guid: str, template_name: str, friendly_name: str,
+                        created_by: str, file_name_string: str,
+                        process_json: dict | str, template_guid: str) -> None:
+    """Insert a record into ``dbo.MAPPING_AGENT_PROCESSES``."""
+    with _connect() as conn:
+        conn.cursor().execute(
+            "INSERT INTO dbo.MAPPING_AGENT_PROCESSES (PROCESS_GUID, TEMPLATE_NAME, FRIENDLY_NAME, CREATED_BY, CREATED_DTTM, FILE_NAME_STRING, PROCESS_JSON, TEMPLATE_GUID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (process_guid, template_name, friendly_name, created_by, datetime.utcnow(), file_name_string,
+             json.dumps(process_json) if not isinstance(process_json, str) else process_json, template_guid),
+        )

--- a/tests/test_log_mapping_process.py
+++ b/tests/test_log_mapping_process.py
@@ -1,0 +1,48 @@
+import pytest
+from datetime import datetime
+import json
+
+from app_utils import azure_sql
+
+
+def _fake_conn(captured: dict):
+    class FakeCursor:
+        def execute(self, query, params):  # pragma: no cover - executed via call
+            captured["query"] = query
+            captured["params"] = params
+            return self
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    return FakeConn()
+
+
+@pytest.mark.parametrize("payload,expected", [
+    ({"a": 1}, json.dumps({"a": 1})),
+    ("{\"a\": 1}", "{\"a\": 1}"),
+])
+def test_log_mapping_process(monkeypatch, payload, expected):
+    captured: dict = {}
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    azure_sql.log_mapping_process(
+        "proc", "template-name", "Friendly", "user@example.com",
+        "file.csv", payload, "tmpl-guid",
+    )
+    assert "MAPPING_AGENT_PROCESSES" in captured["query"]
+    params = captured["params"]
+    assert params[0] == "proc"
+    assert params[1] == "template-name"
+    assert params[2] == "Friendly"
+    assert params[3] == "user@example.com"
+    assert isinstance(params[4], datetime)
+    assert params[5] == "file.csv"
+    assert params[6] == expected
+    assert params[7] == "tmpl-guid"


### PR DESCRIPTION
## Summary
- add `log_mapping_process` to record mapping processes in SQL
- test logging helper with a fake pyodbc connection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68961cb2062c83339e2ce0ca51e8de9b