### PR TITLE
Ensure process GUID always included

### DIFF
--- a/app_utils/mapping/exporter.py
+++ b/app_utils/mapping/exporter.py
@@ -39,9 +39,13 @@ def _apply_lookup_mapping(layer: Dict[str, Any], idx: int, state: MutableMapping
 def build_output_template(
     template: Template,
     state: MutableMapping[str, Any],
-    process_guid: str | None = None,
+    process_guid: str,
 ) -> Dict[str, Any]:
-    """Return template JSON enriched with user expressions."""
+    """Return template JSON enriched with user expressions.
+
+    ``process_guid`` is always embedded in the returned JSON so downstream
+    systems can trace a specific mapping run.
+    """
     tpl = deepcopy(template.model_dump(mode="json"))
     layers = []
     for idx, layer in enumerate(tpl.get("layers", [])):
@@ -54,6 +58,5 @@ def build_output_template(
         else:
             layers.append(layer)
     tpl["layers"] = layers
-    if process_guid:
-        tpl["process_guid"] = process_guid
+    tpl["process_guid"] = process_guid
     return tpl

--- a/cli.py
+++ b/cli.py
@@ -83,9 +83,7 @@ def main() -> None:
     template = load_template(args.template)
     df = load_data(args.input_file)
     state = auto_map(template, df)
-    process_guid: str | None = None
-    if args.operation_code and template.template_name == "PIT BID":
-        process_guid = str(uuid.uuid4())
+    process_guid = str(uuid.uuid4())
     mapped = build_output_template(template, state, process_guid)
 
     with args.output.open("w") as f:
@@ -93,11 +91,7 @@ def main() -> None:
 
     if args.csv_output:
         mapped_df = save_mapped_csv(df, mapped, args.csv_output)
-        if (
-            args.operation_code
-            and template.template_name == "PIT BID"
-            and process_guid is not None
-        ):
+        if args.operation_code and template.template_name == "PIT BID":
             rows = azure_sql.insert_pit_bid_rows(
                 mapped_df, args.operation_code, args.customer_name, process_guid
             )

--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -21,6 +21,7 @@ from app_utils.ui.header_utils import (
     persist_suggestions_from_mapping,
 )
 from app_utils.ui_utils import set_steps_from_template
+import uuid
 
 # ─── CSS tweaks ───────────────────────────────────────────────────────
 st.markdown(
@@ -247,7 +248,9 @@ def render(layer, idx: int) -> None:
         tpl_raw = st.session_state.get("template")
         if tpl_raw is not None:
             tpl_obj = Template.model_validate(tpl_raw)
-            tpl_json = build_output_template(tpl_obj, st.session_state)
+            tpl_json = build_output_template(
+                tpl_obj, st.session_state, str(uuid.uuid4())
+            )
             import tempfile
 
             with tempfile.NamedTemporaryFile(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ def test_cli_basic(tmp_path: Path):
     fields = {f['key']: f.get('source') for f in header_layer['fields']}
     assert fields['Name'] == 'Name'
     assert fields['Value'] == 'Value'
+    assert data['process_guid']
 
 
 def test_cli_csv_output(tmp_path: Path):
@@ -37,9 +38,11 @@ def test_cli_csv_output(tmp_path: Path):
         str(out_csv),
     ])
 
+    data = json.loads(out_json.read_text())
     content = out_csv.read_text().strip().splitlines()
     assert content[0] == 'Name,Value'
     assert content[1] == 'Alice,1'
+    assert data['process_guid']
 
 
 def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -25,7 +25,7 @@ def test_expressions_in_output():
             "expression": "df['A'] - df['B']"
         }
     }
-    out = build_output_template(template, state)
+    out = build_output_template(template, state, process_guid="guid1")
     header_layer = out["layers"][0]
     net_change = next(f for f in header_layer["fields"] if f["key"] == "NET_CHANGE")
     assert net_change["expression"] == "df['A'] + df['B']"
@@ -43,7 +43,7 @@ def test_extra_fields_preserved():
         "header_mapping_0": {"NEW_COL": {"src": "A"}},
         "header_extra_fields_0": ["NEW_COL"],
     }
-    out = build_output_template(template, state)
+    out = build_output_template(template, state, process_guid="guid2")
     header_layer = out["layers"][0]
     added = next(f for f in header_layer["fields"] if f["key"] == "NEW_COL")
     assert added["source"] == "A"
@@ -55,7 +55,7 @@ def test_extra_field_expression():
         "header_mapping_0": {"ADDED": {"expr": "df['A']*2"}},
         "header_extra_fields_0": ["ADDED"],
     }
-    out = build_output_template(template, state)
+    out = build_output_template(template, state, process_guid="guid3")
     header_layer = out["layers"][0]
     added = next(f for f in header_layer["fields"] if f["key"] == "ADDED")
     assert added["expression"] == "df['A']*2"
@@ -71,6 +71,6 @@ def test_process_guid_added():
 def test_lookup_mapping_saved():
     template = load_sample("standard-fm-coa")
     state = {"lookup_mapping_1": {"STD": "Client"}}
-    out = build_output_template(template, state)
+    out = build_output_template(template, state, process_guid="guid4")
     lookup_layer = out["layers"][1]
     assert lookup_layer["mapping"]["STD"] == "Client"


### PR DESCRIPTION
## Summary
- Require `process_guid` in `build_output_template` and embed it in template JSON
- Generate a fresh UUID for each mapping run in CLI and Streamlit header step
- Update tests for unconditional `process_guid` output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689629e584fc833383e31525c467f246