### PR TITLE
Remove deprecated Miles and Tolls PIT mappings

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -23,8 +23,6 @@ PIT_BID_FIELD_MAP: Dict[str, str] = {
     "Bid Volume": "BID_VOLUME",
     "LH Rate": "LH_RATE",
     "Bid Miles": "RFP_MILES",
-    "Miles": "RFP_MILES",
-    "Tolls": "FM_TOLLS",
     "Customer Name": "CUSTOMER_NAME",
     "Freight Type": "FREIGHT_TYPE",
     "Temp Cat": "TEMP_CAT",


### PR DESCRIPTION
## Summary
- drop `Miles` and `Tolls` from `PIT_BID_FIELD_MAP`
- align PIT mapping tests with removed aliases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689629c63bd88333b1179a22da174530