### PR TITLE
Log mapping processes

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import streamlit as st
 from pydantic import ValidationError
+import auth
 try:
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover - optional dependency
@@ -36,6 +37,8 @@ from app_utils.azure_sql import (
     get_operational_scac,
     insert_pit_bid_rows,
 )
+from app_utils import azure_sql
+from app_utils.template_builder import slugify
 from schemas.template_v2 import Template
 from app_utils.ui_utils import render_progress, set_steps_from_template
 from app_utils.excel_utils import list_sheets, read_tabular_file, save_mapped_csv
@@ -319,6 +322,15 @@ def main():
                         guid,
                         st.session_state.get("operation_code"),
                         st.session_state.get("customer_name"),
+                    )
+                    azure_sql.log_mapping_process(
+                        guid,
+                        slugify(template_obj.template_name),
+                        template_obj.template_name,
+                        auth.get_user_email(),
+                        selected_file,
+                        json.dumps(final_json),
+                        template_obj.template_guid,
                     )
                     st.session_state["postprocess_payload"] = payload
                     logs.extend(logs_post)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 from pathlib import Path
 import sys
 
@@ -7,28 +6,51 @@ import cli
 from app_utils import azure_sql
 
 
-def test_cli_basic(tmp_path: Path):
+def test_cli_basic(monkeypatch, tmp_path: Path):
     tpl = Path('tests/fixtures/simple-template.json')
     src = Path('tests/fixtures/simple.csv')
     out = tmp_path / 'out.json'
+    captured: dict[str, object] = {}
 
-    subprocess.check_call(['python', 'cli.py', str(tpl), str(src), str(out)])
+    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid):
+        captured.update(
+            {
+                'process_guid': process_guid,
+                'template_name': template_name,
+                'friendly_name': friendly_name,
+                'user_email': user_email,
+                'file_name_string': file_name_string,
+                'process_json': process_json,
+                'template_guid': template_guid,
+            }
+        )
+
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', fake_log)
+    monkeypatch.setattr(sys, 'argv', [
+        'cli.py', str(tpl), str(src), str(out), '--user-email', 'user@example.com'
+    ])
+    cli.main()
 
     data = json.loads(out.read_text())
     header_layer = data['layers'][0]
     fields = {f['key']: f.get('source') for f in header_layer['fields']}
     assert fields['Name'] == 'Name'
     assert fields['Value'] == 'Value'
+    assert data['process_guid'] == captured['process_guid']
+    assert captured['template_name'] == tpl.stem
+    assert captured['friendly_name'] == 'simple-template'
+    assert captured['user_email'] == 'user@example.com'
+    assert captured['file_name_string'] == tpl.name
 
 
-def test_cli_csv_output(tmp_path: Path):
+def test_cli_csv_output(monkeypatch, tmp_path: Path):
     tpl = Path('tests/fixtures/simple-template.json')
     src = Path('tests/fixtures/simple.csv')
     out_json = tmp_path / 'out.json'
     out_csv = tmp_path / 'out.csv'
 
-    subprocess.check_call([
-        'python',
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
+    monkeypatch.setattr(sys, 'argv', [
         'cli.py',
         str(tpl),
         str(src),
@@ -36,6 +58,7 @@ def test_cli_csv_output(tmp_path: Path):
         '--csv-output',
         str(out_csv),
     ])
+    cli.main()
 
     content = out_csv.read_text().strip().splitlines()
     assert content[0] == 'Name,Value'
@@ -66,6 +89,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
         'run_postprocess_if_configured',
         lambda tpl_obj, df, guid, operation_code=None, customer_name=None: ([], None),
     )
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
     monkeypatch.setattr(sys, 'argv', [
         'cli.py',
         str(tpl),
@@ -112,6 +136,7 @@ def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path, capsys):
 
     monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
     monkeypatch.setattr(cli, 'run_postprocess_if_configured', fake_postprocess)
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
     monkeypatch.setattr(sys, 'argv', [
         'cli.py',
         str(tpl),


### PR DESCRIPTION
## Summary
- log every CLI mapping run with process GUID and user email
- streamlit wizard records mapping process after post-processing
- add tests for process GUID creation and logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689629a11e50833391bb44749194b548