### PR TITLE
Refine Azure SQL tests for freight type auto-fill

### DIFF
--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -22,8 +22,6 @@ def test_pit_bid_field_map_alignment():
         "Bid Volume": "BID_VOLUME",
         "LH Rate": "LH_RATE",
         "Bid Miles": "RFP_MILES",
-        "Miles": "RFP_MILES",
-        "Tolls": "FM_TOLLS",
         "Customer Name": "CUSTOMER_NAME",
         "Freight Type": "FREIGHT_TYPE",
         "Temp Cat": "TEMP_CAT",
@@ -202,6 +200,7 @@ def _fake_conn(captured: dict, columns: set[str] | None = None):
 def test_insert_pit_bid_rows(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "Lane ID": ["L1"],
@@ -214,7 +213,6 @@ def test_insert_pit_bid_rows(monkeypatch):
             "Bid Volume": [5],
             "LH Rate": [1.2],
             "Bid Miles": [100],
-            "Tolls": [7],
             "Foo": ["bar"],
         }
     )
@@ -237,6 +235,7 @@ def test_insert_pit_bid_rows(monkeypatch):
 def test_insert_pit_bid_rows_blanks(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "Lane ID": ["L1"],
@@ -249,7 +248,6 @@ def test_insert_pit_bid_rows_blanks(monkeypatch):
             "Bid Volume": [""],
             "LH Rate": [""],
             "Bid Miles": [""],
-            "Tolls": [""],
         }
     )
     rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer", "guid")
@@ -257,12 +255,12 @@ def test_insert_pit_bid_rows_blanks(monkeypatch):
     assert captured["params"][9] is None  # BID_VOLUME
     assert captured["params"][10] is None  # LH_RATE
     assert captured["params"][24] is None  # RFP_MILES
-    assert captured["params"][25] is None  # RFP_TOLLS
 
 
 def test_insert_pit_bid_rows_with_db_columns(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "LANE_ID": ["L1"],
@@ -274,7 +272,7 @@ def test_insert_pit_bid_rows_with_db_columns(monkeypatch):
             "DEST_POSTAL_CD": ["22222"],
             "BID_VOLUME": [5],
             "LH_RATE": [1.2],
-            "Miles": [123],
+            "RFP_MILES": [123],
         }
     )
     rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
@@ -284,25 +282,20 @@ def test_insert_pit_bid_rows_with_db_columns(monkeypatch):
     assert captured["params"][14] is None  # no ADHOC columns
 
 
-def test_insert_pit_bid_rows_prefer_bid_miles(monkeypatch):
+def test_insert_pit_bid_rows_autofill_freight_type(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
-    df = pd.DataFrame(
-        {
-            "Lane ID": ["L1"],
-            "Bid Miles": [321],
-            "Miles": [999],
-        }
-    )
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: "LTL")
+    df = pd.DataFrame({"Lane ID": ["L1"]})
     rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
     assert rows == 1
-    assert captured["params"][2] == "L1"
-    assert captured["params"][24] == 321  # from Bid Miles
-    assert captured["params"][14] is None  # Miles not treated as ADHOC
+    assert captured["params"][11] == "LTL"
+
 
 def test_insert_pit_bid_rows_formatted_numbers(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "Lane ID": ["L1"],
@@ -311,7 +304,6 @@ def test_insert_pit_bid_rows_formatted_numbers(monkeypatch):
             "Bid Volume": ["5,000"],
             "LH Rate": ["$1.50"],
             "Bid Miles": ["1,234"],
-            "Tolls": ["$2.25"],
         }
     )
     rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
@@ -321,11 +313,11 @@ def test_insert_pit_bid_rows_formatted_numbers(monkeypatch):
     assert captured["params"][9] == 5000.0
     assert captured["params"][10] == 1.5
     assert captured["params"][24] == 1234.0
-    assert captured["params"][25] == 2.25
 
 def test_insert_pit_bid_rows_customer_column(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "Customer Name": ["Cust1"],
@@ -361,6 +353,7 @@ def test_insert_pit_bid_rows_extends_known_columns(monkeypatch):
     captured = {}
     table_cols = {"EXTRA_COL"}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured, table_cols))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     monkeypatch.setitem(azure_sql.PIT_BID_FIELD_MAP, "Extra Field", "EXTRA_COL")
     df = pd.DataFrame({"Lane ID": ["L1"], "Extra Field": ["val"]})
     rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
@@ -373,6 +366,7 @@ def test_insert_pit_bid_rows_extends_known_columns(monkeypatch):
 def test_insert_pit_bid_rows_unknown_columns_to_adhoc(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     monkeypatch.setitem(azure_sql.PIT_BID_FIELD_MAP, "Extra Field", "MISSING_COL")
     df = pd.DataFrame({"Lane ID": ["L1"], "Extra Field": ["val"]})
     rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")

--- a/tests/test_insert_pit_bid_rows_adhoc.py
+++ b/tests/test_insert_pit_bid_rows_adhoc.py
@@ -37,6 +37,7 @@ def _fake_conn(captured):
 def test_insert_pit_bid_rows_adhoc_sequential(monkeypatch):
     captured: dict = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "Lane ID": ["L1"],
@@ -59,6 +60,7 @@ def test_insert_pit_bid_rows_adhoc_sequential(monkeypatch):
 def test_insert_pit_bid_rows_preserves_existing_adhoc(monkeypatch):
     captured: dict = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
         {
             "Lane ID": ["L1"],


### PR DESCRIPTION
## Summary
- drop `Miles` and `Tolls` aliases from PIT bid field map
- add `fetch_freight_type` helper and auto-fill missing Freight Type values
- update Azure SQL tests and ADHOC fixtures for new Freight Type logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689629fedf0083339ee37be0656fa8b1