### PR TITLE
Add optional ADHOC_INFO fields to pit bid template

### DIFF
--- a/templates/pit-bid.json
+++ b/templates/pit-bid.json
@@ -56,6 +56,46 @@
         {
           "key": "Breakthrough Fuel",
           "required": false
+        },
+        {
+          "key": "ADHOC_INFO1",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO2",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO3",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO4",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO5",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO6",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO7",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO8",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO9",
+          "required": false
+        },
+        {
+          "key": "ADHOC_INFO10",
+          "required": false
         }
       ]
     }


### PR DESCRIPTION
## Summary
- extend pit-bid template with optional ADHOC_INFO1-10 fields under header

## Testing
- `python - <<'PY'
from schemas.template_v2 import Template
import pathlib
path = pathlib.Path('templates/pit-bid.json')
Template.model_validate_json(path.read_text())
print('validated')
PY`
- `pytest tests/test_template_builder.py tests/test_validator.py tests/test_cli.py tests/test_wizard_postprocess.py tests/test_exporter.py tests/test_insert_pit_bid_rows_adhoc.py tests/test_azure_sql.py`


------
https://chatgpt.com/codex/tasks/task_b_689639511b948333b53ae3b2f21d8034