### PR TITLE
Persist adhoc header mapping for PIT BID processes

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,11 +307,13 @@ def main():
                         tmp_path = Path(tmp.name)
                         mapped_df = save_mapped_csv(df, final_json, tmp_path)
 
+                    adhoc_headers = azure_sql.derive_adhoc_headers(mapped_df)
                     rows = insert_pit_bid_rows(
                         mapped_df,
                         st.session_state["operation_code"],
                         st.session_state.get("customer_name"),
                         guid,
+                        adhoc_headers,
                     )
                     logs = [
                         f"Inserted {rows} rows into RFP_OBJECT_DATA"
@@ -331,6 +333,7 @@ def main():
                         selected_file,
                         json.dumps(final_json),
                         template_obj.template_guid,
+                        adhoc_headers,
                     )
                     st.session_state["postprocess_payload"] = payload
                     logs.extend(logs_post)

--- a/cli.py
+++ b/cli.py
@@ -96,12 +96,17 @@ def main() -> None:
 
     if args.csv_output:
         mapped_df = save_mapped_csv(df, mapped, args.csv_output)
+        adhoc_headers = azure_sql.derive_adhoc_headers(mapped_df)
         if (
             args.operation_code
             and template.template_name == "PIT BID"
         ):
             rows = azure_sql.insert_pit_bid_rows(
-                mapped_df, args.operation_code, args.customer_name, process_guid
+                mapped_df,
+                args.operation_code,
+                args.customer_name,
+                process_guid,
+                adhoc_headers,
             )
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
             logs_post, payload = run_postprocess_if_configured(
@@ -120,6 +125,7 @@ def main() -> None:
         args.template.name,
         json.dumps(mapped),
         template.template_guid,
+        adhoc_headers if args.csv_output else None,
     )
 
 

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -216,7 +216,9 @@ def test_insert_pit_bid_rows(monkeypatch):
             "Foo": ["bar"],
         }
     )
-    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer", "guid")
+    rows = azure_sql.insert_pit_bid_rows(
+        df, "OP", "Customer", "guid", {"ADHOC_INFO1": "Foo"}
+    )
     assert rows == 1
     assert "RFP_OBJECT_DATA" in captured["query"]
     assert captured["params"][0] == "OP"

--- a/tests/test_derive_adhoc_headers.py
+++ b/tests/test_derive_adhoc_headers.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from app_utils import azure_sql
+
+
+def _fake_conn():
+    class FakeCursor:
+        def execute(self, query, params=None):  # pragma: no cover - executed via call
+            return self
+
+        def fetchall(self):  # pragma: no cover - executed via call
+            return []
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    return FakeConn()
+
+
+def test_derive_adhoc_headers(monkeypatch):
+    monkeypatch.setattr(azure_sql, "_connect", _fake_conn)
+    df = pd.DataFrame({"Lane ID": ["L1"], "Foo": ["x"], "Bar": ["y"]})
+    mapping = azure_sql.derive_adhoc_headers(df)
+    assert mapping == {"ADHOC_INFO1": "Foo", "ADHOC_INFO2": "Bar"}
+

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -96,9 +96,10 @@ def run_app(monkeypatch):
     )
     monkeypatch.setattr("app_utils.azure_sql.fetch_customers", lambda scac: [])
     monkeypatch.setattr(
-        "app_utils.azure_sql.insert_pit_bid_rows", lambda df, op, cust, guid: len(df)
+        "app_utils.azure_sql.insert_pit_bid_rows", lambda df, op, cust, guid, adhoc: len(df)
     )
-    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid):
+    monkeypatch.setattr("app_utils.azure_sql.derive_adhoc_headers", lambda df: {})
+    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, adhoc_headers=None):
         called["log_guid"] = process_guid
         called["log_template"] = template_name
         called["log_friendly"] = friendly_name


### PR DESCRIPTION
## Summary
- support optional adhoc header mapping when inserting PIT BID rows
- log adhoc header map with each mapping process
- cover adhoc header derivation and logging in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896398e41888333855b1c250ab33e85