### PR TITLE
Require customer name for PIT bid inserts

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,8 @@ def main():
             "export_complete",
             "export_logs",
             "final_json",
+            "customer_name",
+            "selected_customer",
         ]:
             st.session_state.pop(k, None)
         st.session_state["current_step"] = 0
@@ -211,21 +213,16 @@ def main():
         cust_records = st.session_state["customer_options"]
         cust_names = [c["BILLTO_NAME"] for c in cust_records]
         if cust_names:
-            options = [""] + cust_names
             idx = 0
             if st.session_state.get("customer_name") in cust_names:
-                idx = cust_names.index(st.session_state["customer_name"]) + 1
+                idx = cust_names.index(st.session_state["customer_name"])
             selected_name = st.selectbox(
-                "Customer (optional)", options, index=idx, key="customer_name_select"
+                "Customer", cust_names, index=idx, key="customer_name_select"
             )
-            if selected_name:
-                st.session_state["customer_name"] = selected_name
-                st.session_state["selected_customer"] = next(
-                    c for c in cust_records if c["BILLTO_NAME"] == selected_name
-                )
-            else:
-                st.session_state["customer_name"] = None
-                st.session_state["selected_customer"] = None
+            st.session_state["customer_name"] = selected_name
+            st.session_state["selected_customer"] = next(
+                c for c in cust_records if c["BILLTO_NAME"] == selected_name
+            )
         else:
             st.warning("No customers found for selected operation.")
 
@@ -311,7 +308,7 @@ def main():
                     rows = insert_pit_bid_rows(
                         mapped_df,
                         st.session_state["operation_code"],
-                        st.session_state.get("customer_name"),
+                        st.session_state["customer_name"],
                         guid,
                         adhoc_headers,
                     )
@@ -322,8 +319,8 @@ def main():
                         template_obj,
                         df,
                         guid,
-                        st.session_state.get("operation_code"),
-                        st.session_state.get("customer_name"),
+                        st.session_state["operation_code"],
+                        st.session_state["customer_name"],
                     )
                     azure_sql.log_mapping_process(
                         guid,

--- a/cli.py
+++ b/cli.py
@@ -76,7 +76,7 @@ def main() -> None:
     parser.add_argument(
         "--customer-name",
         type=str,
-        help="Optional customer name for SQL insert",
+        help="Customer name for SQL insert",
     )
     parser.add_argument(
         "--user-email",
@@ -101,6 +101,8 @@ def main() -> None:
             args.operation_code
             and template.template_name == "PIT BID"
         ):
+            if not args.customer_name:
+                parser.error("--customer-name is required when --operation-code is provided")
             rows = azure_sql.insert_pit_bid_rows(
                 mapped_df,
                 args.operation_code,

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -317,8 +317,8 @@ def test_insert_pit_bid_rows_formatted_numbers(monkeypatch):
     assert captured["params"][10] == 1.5
     assert captured["params"][24] == 1234.0
 
-def test_insert_pit_bid_rows_customer_column(monkeypatch):
-    captured = {}
+def test_insert_pit_bid_rows_customer_column_ignored(monkeypatch):
+    captured: dict = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
     monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
     df = pd.DataFrame(
@@ -329,13 +329,13 @@ def test_insert_pit_bid_rows_customer_column(monkeypatch):
             "Orig State": ["OS"],
         }
     )
-    rows = azure_sql.insert_pit_bid_rows(df, "OP", None)
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
     assert rows == 1
-    assert captured["params"][1] == "Cust1"
+    assert captured["params"][1] == "Customer"
 
 
 def test_insert_pit_bid_rows_unmapped_no_alias(monkeypatch):
-    captured = {}
+    captured: dict = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
     df = pd.DataFrame(
         {
@@ -344,9 +344,9 @@ def test_insert_pit_bid_rows_unmapped_no_alias(monkeypatch):
             "Foo": ["bar"],
         }
     )
-    rows = azure_sql.insert_pit_bid_rows(df, "OP", None)
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
     assert rows == 1
-    assert captured["params"][1] is None  # CUSTOMER_NAME
+    assert captured["params"][1] == "Customer"  # CUSTOMER_NAME
     assert captured["params"][11] == "TL"  # FREIGHT_TYPE
     assert captured["params"][14] == "Acme"  # ADHOC_INFO1
     assert captured["params"][15] == "bar"  # ADHOC_INFO2

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -132,6 +132,7 @@ def run_app(monkeypatch):
         "template": tpl_data,
         "template_name": "PIT BID",
         "current_template": "PIT BID",
+        "customer_name": "Customer",
         "layer_confirmed_0": True,
     })
     sys.modules.pop("app", None)


### PR DESCRIPTION
## Summary
- make customer name a required argument for Azure SQL PIT bid inserts and remove per-row overrides
- require customer selection in Streamlit app and CLI with validation
- update tests for mandatory customer name and removed per-row behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68963c943b948333bc4a5e458926870c