### PR TITLE
Require customer name for postprocess

### DIFF
--- a/app.py
+++ b/app.py
@@ -322,8 +322,8 @@ def main():
                         template_obj,
                         df,
                         guid,
+                        st.session_state.get("customer_name", ""),
                         st.session_state.get("operation_code"),
-                        st.session_state.get("customer_name"),
                     )
                     azure_sql.log_mapping_process(
                         guid,

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 import json
-from datetime import datetime
 import pandas as pd
 from schemas.template_v2 import PostprocessSpec, Template
 from app_utils.dataframe_transform import apply_header_mappings
@@ -33,8 +32,8 @@ def run_postprocess_if_configured(
     template: Template,
     df: pd.DataFrame,
     process_guid: str,
+    customer_name: str,
     operation_cd: str | None = None,
-    customer_name: str | None = None,
 ) -> Tuple[List[str], Dict[str, Any] | List[Dict[str, Any]] | None]:
     """Run optional postprocess hooks based on ``template``."""
 
@@ -55,9 +54,7 @@ def run_postprocess_if_configured(
             logs.append(f"Payload error: {err}")
             raise
         logs.append(f"Payload: {json.dumps(payload)}")
-        now = datetime.utcnow()
-        stamp = customer_name or now.strftime("%H%M%S")
-        fname = f"{operation_cd} - BID - {stamp} BID.xlsm"
+        fname = f"{operation_cd} - BID - {customer_name} BID.xlsm"
         payload.setdefault("item/In_dtInputData", [{}])
         if not payload["item/In_dtInputData"]:
             payload["item/In_dtInputData"].append({})

--- a/cli.py
+++ b/cli.py
@@ -99,6 +99,7 @@ def main() -> None:
         adhoc_headers = azure_sql.derive_adhoc_headers(mapped_df)
         if (
             args.operation_code
+            and args.customer_name
             and template.template_name == "PIT BID"
         ):
             rows = azure_sql.insert_pit_bid_rows(
@@ -110,7 +111,11 @@ def main() -> None:
             )
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
             logs_post, payload = run_postprocess_if_configured(
-                template, df, process_guid, args.operation_code, args.customer_name
+                template,
+                df,
+                process_guid,
+                args.customer_name,
+                args.operation_code,
             )
             for line in logs_post:
                 print(line)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,7 +93,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
     monkeypatch.setattr(
         cli,
         'run_postprocess_if_configured',
-        lambda tpl_obj, df, guid, operation_code=None, customer_name=None: ([], None),
+        lambda tpl_obj, df, guid, customer_name, operation_code=None: ([], None),
     )
     monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
     monkeypatch.setattr(sys, 'argv', [
@@ -133,7 +133,7 @@ def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path, capsys):
     captured: dict[str, object] = {}
 
     def fake_postprocess(
-        tpl_obj, df, process_guid, op_cd, cust_name
+        tpl_obj, df, process_guid, cust_name, op_cd
     ):
         captured['op'] = op_cd
         captured['cust'] = cust_name

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -133,6 +133,7 @@ def run_app(monkeypatch):
         "template_name": "PIT BID",
         "current_template": "PIT BID",
         "layer_confirmed_0": True,
+        "customer_name": "Cust",
     })
     sys.modules.pop("app", None)
     importlib.import_module("app")


### PR DESCRIPTION
## Summary
- require `customer_name` when running postprocess hooks
- use provided customer name directly in PIT BID filename
- update app, CLI and tests to pass customer name explicitly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68963c9905d88333bf7dc9b156154fab