### PR TITLE
Auto-update default AdHoc labels on mapping

### DIFF
--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -156,6 +156,12 @@ def render(layer, idx: int) -> None:
                 },
                 headers=source_cols,
             )
+            if key.startswith("ADHOC_INFO"):
+                match = re.findall(r"\d+", key)
+                default = f"AdHoc{match[0] if match else ''}"
+                label = adhoc_labels.get(key, default)
+                if label == default:
+                    adhoc_labels[key] = new_src
         elif "src" in mapping.get(key, {}):
             set_field_mapping(key, idx, {})
 


### PR DESCRIPTION
## Summary
- Auto-rename AdHoc field labels to selected source column when still using default name
- Preserve user-defined AdHoc labels when remapping columns
- Add regression tests for AdHoc label updates and persistence

## Testing
- `pytest tests/test_adhoc_labels.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68964a3aa8548333ae0114d5eebfdfb8