### PR TITLE
Vectorize and batch PIT BID inserts

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -232,6 +232,10 @@ def insert_pit_bid_rows(
     customer_name: str,
     process_guid: str | None = None,
     adhoc_headers: Dict[str, str] | None = None,
+    *,
+    batch_size: int = 1000,
+    tvp_name: str | None = None,
+    use_bulk_insert: bool = False,
 ) -> int:
     """Insert mapped ``pit-bid`` rows into ``dbo.RFP_OBJECT_DATA``.
 
@@ -303,8 +307,6 @@ def insert_pit_bid_rows(
         text = str(val).strip()
         return text or None
 
-
-    # Rename DataFrame columns to their target database names.
     df_db = df.rename(columns=PIT_BID_FIELD_MAP).copy()
     if df_db.columns.duplicated().any():
         for col in df_db.columns[df_db.columns.duplicated()].unique():
@@ -321,7 +323,7 @@ def insert_pit_bid_rows(
         cur = conn.cursor()
         cur.execute(
             "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'dbo' "
-            "AND TABLE_NAME = 'RFP_OBJECT_DATA'"
+            "AND TABLE_NAME = 'RFP_OBJECT_DATA'",
         )
         db_columns = {row[0] for row in cur.fetchall()}
         extra_columns = [
@@ -333,36 +335,66 @@ def insert_pit_bid_rows(
             and col not in adhoc_slots
         ]
         columns = base_columns + extra_columns + adhoc_slots + tail_columns
-        placeholders = ",".join(["?"] * len(columns))
+
+        unmapped = [
+            c
+            for c in df_db.columns
+            if c not in base_columns
+            and c not in extra_columns
+            and c not in adhoc_slots
+            and c not in tail_columns
+        ]
+        available_slots = [slot for slot in adhoc_slots if slot not in df_db.columns]
+        for slot, col in zip(available_slots, unmapped):
+            df_db[slot] = df_db[col]
+
+        for col in df_db.columns.intersection(float_fields):
+            df_db[col] = df_db[col].map(_to_float)
+        for col in df_db.columns.difference(float_fields):
+            df_db[col] = df_db[col].map(_to_str)
+
         now = datetime.utcnow()
-        rows: list[list[Any]] = []
-        for _, row in df_db.iterrows():
-            values = {c: None for c in columns}
-            values["OPERATION_CD"] = operation_cd
-            values["PROCESS_GUID"] = process_guid
-            values["INSERTED_DTTM"] = now
-            for col in df_db.columns:
-                if col in values:
-                    if col == "CUSTOMER_NAME":
-                        continue
-                    if col in float_fields:
-                        values[col] = _to_float(row[col])
-                    else:
-                        values[col] = _to_str(row[col])
-            values["CUSTOMER_NAME"] = customer_name
-            if values["FREIGHT_TYPE"] is None:
-                values["FREIGHT_TYPE"] = default_freight
-            unmapped = [c for c in df_db.columns if c not in values]
-            available_slots = [slot for slot in adhoc_slots if values[slot] is None]
-            for slot, col in zip(available_slots, unmapped):
-                values[slot] = _to_str(row[col])
-            rows.append([values[c] for c in columns])
-        if rows:
-            cur.fast_executemany = True  # type: ignore[attr-defined]
-            cur.executemany(
-                f"INSERT INTO dbo.RFP_OBJECT_DATA ({','.join(columns)}) VALUES ({placeholders})",
-                rows,
+        df_db = df_db.reindex(columns=columns).astype(object)
+        df_db = df_db.where(pd.notna(df_db), None)
+        df_db["OPERATION_CD"] = operation_cd
+        df_db["CUSTOMER_NAME"] = customer_name
+        df_db["PROCESS_GUID"] = process_guid
+        df_db["INSERTED_DTTM"] = now
+        if default_freight is not None:
+            df_db["FREIGHT_TYPE"] = df_db["FREIGHT_TYPE"].fillna(default_freight)
+
+        rows = list(df_db.itertuples(index=False, name=None))
+        if not rows:
+            return 0
+
+        cur.fast_executemany = True  # type: ignore[attr-defined]
+        placeholders = ",".join(["?"] * len(columns))
+        if tvp_name and pyodbc and hasattr(pyodbc, "TableValuedParam"):
+            tvp = pyodbc.TableValuedParam(tvp_name, rows)  # type: ignore[attr-defined]
+            cur.execute(
+                f"INSERT INTO dbo.RFP_OBJECT_DATA ({','.join(columns)}) SELECT * FROM ?",
+                tvp,
             )
+        elif use_bulk_insert:
+            import csv
+            import tempfile
+
+            with tempfile.NamedTemporaryFile("w", newline="", delete=False) as tmp:
+                csv.writer(tmp).writerows(rows)
+                tmp_path = tmp.name
+            try:
+                cur.execute(
+                    f"BULK INSERT dbo.RFP_OBJECT_DATA FROM '{tmp_path}' WITH (FORMAT = 'CSV')"
+                )
+            finally:
+                os.unlink(tmp_path)
+        else:
+            query = (
+                f"INSERT INTO dbo.RFP_OBJECT_DATA ({','.join(columns)}) VALUES ({placeholders})"
+            )
+            for start in range(0, len(rows), batch_size):
+                batch = rows[start : start + batch_size]
+                cur.executemany(query, batch)
     return len(rows)
 
 

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -1,6 +1,7 @@
 import types
 import pytest
 import pandas as pd
+import types
 
 from app_utils import azure_sql
 
@@ -178,7 +179,9 @@ def _fake_conn(captured: dict, columns: set[str] | None = None):
 
         def executemany(self, query, params):  # pragma: no cover - executed via call
             captured["query"] = query
+            captured.setdefault("batches", []).append(list(params))
             captured["params"] = params[0] if params else None
+            captured["fast_executemany"] = self.fast_executemany
             return self
 
         def fetchall(self):  # pragma: no cover - executed via call
@@ -376,4 +379,35 @@ def test_insert_pit_bid_rows_unknown_columns_to_adhoc(monkeypatch):
     assert rows == 1
     assert captured["params"][14] == "val"  # ADHOC_INFO1
     assert len(captured["params"]) == 29
+
+
+def test_insert_pit_bid_rows_batches(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
+    df = pd.DataFrame({"Lane ID": [f"L{i}" for i in range(1500)]})
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer", batch_size=1000)
+    assert rows == 1500
+    assert len(captured["batches"]) == 2
+    assert len(captured["batches"][0]) == 1000
+    assert len(captured["batches"][1]) == 500
+
+
+def test_insert_pit_bid_rows_tvp(monkeypatch):
+    captured: dict = {}
+
+    class FakeTVP:
+        def __init__(self, name, rows):
+            self.name = name
+            self.rows = rows
+
+    fake_pyodbc = types.SimpleNamespace(TableValuedParam=FakeTVP)
+    monkeypatch.setattr(azure_sql, "pyodbc", fake_pyodbc)
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
+    df = pd.DataFrame({"Lane ID": ["L1", "L2"]})
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer", tvp_name="dbo.TVP")
+    assert rows == 2
+    assert isinstance(captured["params"], FakeTVP)
+    assert captured["params"].name == "dbo.TVP"
 


### PR DESCRIPTION
## Summary
- Vectorize PIT BID row preprocessing and allow optional TVP or BULK INSERT paths
- Enable fast_executemany and submit rows in configurable batches
- Add tests for batching and table-valued parameter handling

## Testing
- `pytest tests/test_insert_pit_bid_rows_adhoc.py tests/test_azure_sql.py`
- `pytest` *(fails: NameError: name 'os' is not defined in app.py)*

------
https://chatgpt.com/codex/tasks/task_b_689660924c048333849b61a40714cce9