### PR TITLE
Validate field lengths against SQL schema

### DIFF
--- a/tests/test_insert_pit_bid_rows_adhoc.py
+++ b/tests/test_insert_pit_bid_rows_adhoc.py
@@ -2,10 +2,10 @@ import pandas as pd
 from app_utils import azure_sql
 
 
-def _fake_conn(captured):
+def _fake_conn(captured, columns: dict[str, int | None] | None = None):
     class FakeCursor:
         def __init__(self) -> None:
-            self.columns: list[str] = []
+            self.columns: dict[str, int | None] = dict(columns or {})
             self.fast_executemany = False
 
         def execute(self, query, params=None):  # pragma: no cover - executed via call
@@ -21,7 +21,7 @@ def _fake_conn(captured):
             return self
 
         def fetchall(self):  # pragma: no cover - executed via call
-            return [(c,) for c in self.columns]
+            return list(self.columns.items())
 
     class FakeConn:
         def cursor(self):


### PR DESCRIPTION
## Summary
- fetch column name and length metadata for RFP_OBJECT_DATA
- raise ValueError when string fields exceed their SQL length
- test length validation using overlong Lane ID

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689671861dec8333949851306f6f905b