### PR TITLE
Handle unlimited SQL column lengths

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -383,7 +383,7 @@ def insert_pit_bid_rows(
         if default_freight is not None:
             df_db["FREIGHT_TYPE"] = df_db["FREIGHT_TYPE"].fillna(default_freight)
         for col, max_len in char_max.items():
-            if max_len is None or col not in df_db.columns:
+            if max_len is None or max_len < 0 or col not in df_db.columns:
                 continue
             mask = df_db[col].notna()
             if not mask.any():

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -331,6 +331,18 @@ def test_insert_pit_bid_rows_length_error(monkeypatch):
         azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
     assert "LANE_ID" in str(exc.value)
 
+
+def test_insert_pit_bid_rows_nvarchar_max(monkeypatch):
+    captured = {}
+    cols = {"ADHOC_INFO1": -1}
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured, cols))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
+    long_val = "x" * 5000
+    df = pd.DataFrame({"Lane ID": ["L1"], "Foo": [long_val]})
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer")
+    assert rows == 1
+    assert captured["params"][14] == long_val
+
 def test_insert_pit_bid_rows_customer_column_ignored(monkeypatch):
     captured: dict = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))


### PR DESCRIPTION
## Summary
- treat SQL columns with NULL or negative length as unlimited in `insert_pit_bid_rows`
- test that NVARCHAR(MAX) columns are accepted without length errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6897ceb2e97c8333a9dc068a387e7090