### PR TITLE
Allow comma-separated customer IDs in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -83,7 +83,8 @@ def main() -> None:
         "--customer-id",
         dest="customer_ids",
         action="append",
-        help="Customer ID(s) for SQL insert (repeatable, up to 5)",
+        default=[],
+        help="Customer ID(s) for SQL insert (repeatable or comma-separated, up to 5)",
     )
     parser.add_argument(
         "--user-email",
@@ -91,6 +92,12 @@ def main() -> None:
         help="User email for process logging",
     )
     args = parser.parse_args()
+
+    ids: list[str] = []
+    for value in args.customer_ids:
+        ids.extend([cid.strip() for cid in value.split(",") if cid.strip()])
+    args.customer_ids = ids
+
     template = load_template(args.template)
     if template.template_name == "PIT BID" and not args.customer_name:
         parser.error("--customer-name is required for PIT BID templates")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,7 +111,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
         '--customer-name',
         'Cust',
         '--customer-id',
-        '1',
+        '1,2',
     ])
 
     cli.main()
@@ -120,7 +120,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
     assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
     assert captured['op'] == 'OP'
     assert captured['cust'] == 'Cust'
-    assert captured['ids'] == ['1']
+    assert captured['ids'] == ['1', '2']
     assert 'Lane ID' in captured['cols']
     assert captured['guid']
     assert data['process_guid'] == captured['guid']
@@ -196,6 +196,32 @@ def test_cli_requires_customer_name_for_pit_bid(monkeypatch, tmp_path: Path):
         'OP',
         '--customer-id',
         '1',
+    ])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+
+def test_cli_requires_customer_id_for_pit_bid(monkeypatch, tmp_path: Path):
+    tpl = Path('templates/pit-bid.json')
+    src = tmp_path / 'src.csv'
+    src.write_text('Lane ID,Bid Volume\nL1,5\n')
+    out_json = tmp_path / 'out.json'
+    out_csv = tmp_path / 'out.csv'
+
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
+    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
+    monkeypatch.setattr(sys, 'argv', [
+        'cli.py',
+        str(tpl),
+        str(src),
+        str(out_json),
+        '--csv-output',
+        str(out_csv),
+        '--operation-code',
+        'OP',
+        '--customer-name',
+        'Cust',
     ])
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- normalize `--customer-id` arguments and ensure at least one ID for PIT BID templates
- test CLI parsing for comma-separated IDs and missing customer IDs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689a3a6511e08333b63529902ccd762f