### PR TITLE
test: cover customer id requirements

### DIFF
--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -221,14 +221,15 @@ def test_insert_pit_bid_rows(monkeypatch):
             "Foo": ["bar"],
         }
     )
+    customer_ids = ["1", "2"]
     rows = azure_sql.insert_pit_bid_rows(
-        df, "OP", "Customer", ["1", "2"], "guid", {"ADHOC_INFO1": "Foo"}
+        df, "OP", "Customer", customer_ids, "guid", {"ADHOC_INFO1": "Foo"}
     )
     assert rows == 1
     assert "RFP_OBJECT_DATA" in captured["query"]
     assert captured["params"][0] == "OP"
     assert captured["params"][1] == "Customer"
-    assert captured["params"][2] == "1,2"
+    assert captured["params"][2] == ",".join(customer_ids)
     assert captured["params"][3] == "L1"
     assert captured["params"][6] == "11111"  # ORIG_POSTAL_CD
     assert captured["params"][9] == "22222"  # DEST_POSTAL_CD

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,8 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
         'Cust',
         '--customer-id',
         '1',
+        '--customer-id',
+        '2',
     ])
 
     cli.main()
@@ -120,7 +122,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
     assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
     assert captured['op'] == 'OP'
     assert captured['cust'] == 'Cust'
-    assert captured['ids'] == ['1']
+    assert captured['ids'] == ['1', '2']
     assert 'Lane ID' in captured['cols']
     assert captured['guid']
     assert data['process_guid'] == captured['guid']
@@ -196,6 +198,32 @@ def test_cli_requires_customer_name_for_pit_bid(monkeypatch, tmp_path: Path):
         'OP',
         '--customer-id',
         '1',
+    ])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+
+def test_cli_requires_customer_id_for_pit_bid(monkeypatch, tmp_path: Path):
+    tpl = Path('templates/pit-bid.json')
+    src = tmp_path / 'src.csv'
+    src.write_text('Lane ID,Bid Volume\nL1,5\n')
+    out_json = tmp_path / 'out.json'
+    out_csv = tmp_path / 'out.csv'
+
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
+    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
+    monkeypatch.setattr(sys, 'argv', [
+        'cli.py',
+        str(tpl),
+        str(src),
+        str(out_json),
+        '--csv-output',
+        str(out_csv),
+        '--operation-code',
+        'OP',
+        '--customer-name',
+        'Cust',
     ])
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- ensure pit-bid inserts join provided customer IDs
- test CLI and UI flows require at least one customer ID

## Testing
- `pytest tests/test_azure_sql.py::test_insert_pit_bid_rows tests/test_azure_sql.py::test_insert_pit_bid_rows_customer_id_column_ignored tests/test_cli.py::test_cli_sql_insert tests/test_cli.py::test_cli_requires_customer_id_for_pit_bid tests/test_customer_required.py::test_pit_bid_requires_customer tests/test_customer_required.py::test_pit_bid_requires_customer_id -q`


------
https://chatgpt.com/codex/tasks/task_b_689a3a6ba5d883338efce4b17cb0f8c5