### PR TITLE
refactor: streamline customer ID selection handlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,6 +233,12 @@ def main():
             ]
             st.session_state["customer_id_options"] = billto_ids
             if billto_ids:
+                def select_all_ids() -> None:
+                    st.session_state["customer_ids"] = billto_ids[:5]
+
+                def deselect_all_ids() -> None:
+                    st.session_state["customer_ids"] = []
+
                 st.multiselect(
                     "Customer ID",
                     billto_ids,
@@ -240,10 +246,8 @@ def main():
                     max_selections=5,
                 )
                 btn_col1, btn_col2 = st.columns(2)
-                if btn_col1.button("Select all"):
-                    st.session_state["customer_ids"] = billto_ids[:5]
-                if btn_col2.button("Deselect all"):
-                    st.session_state["customer_ids"] = []
+                btn_col1.button("Select all", on_click=select_all_ids)
+                btn_col2.button("Deselect all", on_click=deselect_all_ids)
         else:
             st.warning("No customers found for selected operation.")
         if not st.session_state.get("customer_name"):


### PR DESCRIPTION
## Summary
- add `select_all_ids` and `deselect_all_ids` handlers for customer ID multiselect
- move session state changes into on-click callbacks for Select all/Deselect all buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689a3e4cdd4c833385c2adfa88e4752d