### PR TITLE
fix: correct parameter order for postprocess

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -188,8 +188,8 @@ def wait_for_postprocess_completion(
         )
         cur.execute(
             "EXEC dbo.RFP_OBJECT_DATA_POST_PROCESS ?, ?, NULL",
-            operation_cd,
             process_guid,
+            operation_cd,
         )
         conn.commit()
         while True:
@@ -215,8 +215,8 @@ def wait_for_postprocess_completion(
             logger.info("Post-process still running for %s", process_guid)
             cur.execute(
                 "EXEC dbo.RFP_OBJECT_DATA_POST_PROCESS ?, ?, NULL",
-                operation_cd,
                 process_guid,
+                operation_cd,
             )
             conn.commit()
 


### PR DESCRIPTION
## Summary
- pass process GUID before operation code to `RFP_OBJECT_DATA_POST_PROCESS`
- verify stored procedure receives parameters in that order during polling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b933c0b448333b35ece11ad9affd6