### PR TITLE
Limit postprocess polling attempts

### DIFF
--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -224,8 +224,10 @@ def test_pit_bid_null_payload_logged(load_env, monkeypatch):
 def test_wait_for_postprocess_completion_called(monkeypatch):
     called: dict[str, Any] = {}
 
-    def fake_wait(pg: str, op: str, poll_interval: int = 300) -> None:
-        called["args"] = (pg, op, poll_interval)
+    def fake_wait(
+        pg: str, op: str, poll_interval: int = 300, max_attempts: int = 2
+    ) -> None:
+        called["args"] = (pg, op, poll_interval, max_attempts)
         logging.getLogger("app_utils.azure_sql").info("cycle")
 
     monkeypatch.setattr(
@@ -254,6 +256,6 @@ def test_wait_for_postprocess_completion_called(monkeypatch):
         operation_cd="OP",
         poll_interval=1,
     )
-    assert called["args"] == ("guid", "OP", 1)
+    assert called["args"] == ("guid", "OP", 1, 2)
     assert "cycle" in logs
 

--- a/tests/test_wait_for_postprocess_completion.py
+++ b/tests/test_wait_for_postprocess_completion.py
@@ -52,7 +52,9 @@ def test_wait_for_postprocess_completion_reexec(
     caplog.set_level(logging.INFO, logger="app_utils.azure_sql")
     process_guid = "pg"
     operation_cd = "OP"
-    azure_sql.wait_for_postprocess_completion(process_guid, operation_cd, poll_interval=1)
+    azure_sql.wait_for_postprocess_completion(
+        process_guid, operation_cd, poll_interval=1, max_attempts=2
+    )
 
     selects = [c for c in calls if c[0].startswith("SELECT")]
     execs = [c for c in calls if c[0].startswith("EXEC")]
@@ -62,4 +64,53 @@ def test_wait_for_postprocess_completion_reexec(
     assert len(sleeps) == 2
     assert all(params == (process_guid, operation_cd) for _, params in execs)
     assert any("still running" in m for m in caplog.messages)
+
+
+def test_wait_for_postprocess_completion_max_attempts(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Stops after max attempts when postprocess never completes."""
+
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    class DummyCursor:
+        def execute(self, sql: str, *params: Any) -> None:
+            calls.append((sql, params))
+            self._last_sql = sql
+
+        def fetchone(self) -> tuple[Any, ...] | None:
+            if "SELECT" in self._last_sql:
+                return (None,)
+            return None
+
+    class DummyConn:
+        def __enter__(self) -> "DummyConn":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def cursor(self) -> DummyCursor:
+            return DummyCursor()
+
+        def commit(self) -> None:
+            calls.append(("commit", ()))
+
+    monkeypatch.setattr(azure_sql, "_connect", lambda: DummyConn())
+    monkeypatch.setattr(azure_sql.time, "sleep", lambda s: calls.append(("sleep", (s,))))
+
+    caplog.set_level(logging.INFO, logger="app_utils.azure_sql")
+    process_guid = "pg"
+    operation_cd = "OP"
+    azure_sql.wait_for_postprocess_completion(
+        process_guid, operation_cd, poll_interval=1, max_attempts=2
+    )
+
+    selects = [c for c in calls if c[0].startswith("SELECT")]
+    execs = [c for c in calls if c[0].startswith("EXEC")]
+    sleeps = [c for c in calls if c[0] == "sleep"]
+    assert len(selects) == 2
+    assert len(execs) == 2
+    assert len(sleeps) == 2
+    assert any("did not complete" in m for m in caplog.messages)
 


### PR DESCRIPTION
## Summary
- add `max_attempts` parameter to `wait_for_postprocess_completion` and warn when incomplete
- exercise polling limit and non-completion behaviour in tests
- adapt postprocess runner test for new parameter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bb65b93848333a83d80e13b43812c