### PR TITLE
Require file upload before customer selection

### DIFF
--- a/tests/test_customer_grouping.py
+++ b/tests/test_customer_grouping.py
@@ -43,8 +43,8 @@ class DummySidebar:
     def subheader(self, *a: Any, **k: Any) -> None:
         pass
 
-    def selectbox(self, label: str, options: list[str], index: int = 0, key: str | None = None, **k: Any) -> str | None:
-        choice = options[index] if options else None
+    def selectbox(self, label: str, options: list[str], index: int | None = 0, key: str | None = None, **k: Any) -> str | None:
+        choice = options[index] if options and index is not None else None
         if key:
             self.st.session_state[key] = choice
         return choice
@@ -78,10 +78,10 @@ class DummyStreamlit:
     def markdown(self, *a: Any, **k: Any) -> None:
         pass
 
-    def selectbox(self, label: str, options: list[str], index: int = 0, key: str | None = None, **k: Any) -> str | None:
+    def selectbox(self, label: str, options: list[str], index: int | None = 0, key: str | None = None, **k: Any) -> str | None:
         if label == "Customer":
             self.customer_options = options
-        choice = options[index] if options else None
+        choice = options[index] if options and index is not None else None
         if key:
             self.session_state[key] = choice
         return choice
@@ -146,7 +146,7 @@ def run_app(monkeypatch):
     ]
     monkeypatch.setattr("app_utils.azure_sql.fetch_customers", lambda scac: customers)
     monkeypatch.setattr("app_utils.azure_sql.get_operational_scac", lambda op: "SCAC")
-    st.session_state.update({"template_name": "PIT BID"})
+    st.session_state.update({"template_name": "PIT BID", "uploaded_file": object()})
     sys.modules.pop("app", None)
     importlib.import_module("app")
     return st
@@ -155,4 +155,4 @@ def run_app(monkeypatch):
 def test_customer_grouping(monkeypatch):
     st = run_app(monkeypatch)
     assert st.customer_options == ["Boise Cascade"]
-    assert st.session_state["customer_id_options"] == ["A", "B"]
+    assert "customer_id_options" not in st.session_state

--- a/tests/test_customer_required.py
+++ b/tests/test_customer_required.py
@@ -37,7 +37,7 @@ class DummySidebar:
         pass
 
     def selectbox(self, label, options, index=0, key=None, **k):
-        choice = options[index] if options else None
+        choice = options[index] if options and index is not None else None
         if key:
             self.st.session_state[key] = choice
         return choice
@@ -72,9 +72,9 @@ class DummyStreamlit:
 
     def selectbox(self, label, options, index=0, key=None, **k):
         if label == "Customer":
-            choice = None
+            choice = None if index is None else options[index]
         else:
-            choice = options[index] if options else None
+            choice = options[index] if options and index is not None else None
         if key:
             self.session_state[key] = choice
         return choice
@@ -86,7 +86,7 @@ class DummyStreamlit:
         return choice
 
     def file_uploader(self, *a, **k):
-        raise RuntimeError("file_uploader should not run when no customer selected")
+        return None
 
     def spinner(self, *a, **k):
         return DummyContainer()
@@ -125,7 +125,7 @@ def run_app(monkeypatch, customers=None):
         lambda scac: customers or [],
     )
     monkeypatch.setattr("app_utils.azure_sql.get_operational_scac", lambda op: "SCAC")
-    st.session_state.update({"template_name": "PIT BID"})
+    st.session_state.update({"template_name": "PIT BID", "uploaded_file": object()})
     sys.modules.pop("app", None)
     importlib.import_module("app")
     return st
@@ -148,7 +148,7 @@ def test_pit_bid_requires_customer_id(monkeypatch):
     ]
 
     def selectbox(self, label, options, index=0, key=None, **k):
-        choice = options[index] if options else None
+        choice = options[0] if options else None
         if key:
             self.session_state[key] = choice
         return choice

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -66,7 +66,7 @@ class DummyStreamlit:
     def success(self, msg, *a, **k):
         self.success_messages.append(msg)
     def selectbox(self, label, options, index=0, key=None, **k):
-        choice = options[index]
+        choice = options[index] if options and index is not None else None
         if key:
             self.session_state[key] = choice
         return choice
@@ -110,6 +110,8 @@ def run_app(monkeypatch):
     st = DummyStreamlit()
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setenv("DISABLE_AUTH", "1")
+    monkeypatch.setenv("CLIENT_DEST_SITE", "https://tenant.sharepoint.com/sites/demo")
+    monkeypatch.setenv("CLIENT_DEST_FOLDER_PATH", "docs/folder")
     monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
     monkeypatch.setattr("auth.logout_button", lambda: None)
     monkeypatch.setattr("app_utils.excel_utils.list_sheets", lambda _u: ["Sheet1"])
@@ -198,6 +200,5 @@ def test_sharepoint_link_displayed(monkeypatch):
     _, _, st = run_app(monkeypatch)
     assert any("mileage and toll data" in m for m in st.spinner_messages)
     link = "https://tenant.sharepoint.com/sites/demo/docs/folder"
-    messages = st.success_messages + st.info_messages
-    assert any(link in m for m in messages)
+    assert any(link in m for m in st.markdown_calls)
 


### PR DESCRIPTION
## Summary
- Move data-file upload to run before PIT BID customer selection and gate customer UI on uploaded file
- Default PIT BID customer dropdown to no selection with placeholder and only show ID multiselect after a customer is chosen
- Update tests for new workflow and add environment setup for SharePoint link generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c9e4b55d88333b51a8dba8f002963