### PR TITLE
Auto-select single customer ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -269,21 +269,26 @@ def main():
                     ]
                     st.session_state["customer_id_options"] = billto_ids
                     if billto_ids:
-                        def select_all_ids() -> None:
-                            st.session_state["customer_ids"] = billto_ids[:5]
+                        if len(billto_ids) == 1 and not st.session_state.get(
+                            "customer_ids"
+                        ):
+                            st.session_state["customer_ids"] = billto_ids[:1]
+                        else:
+                            def select_all_ids() -> None:
+                                st.session_state["customer_ids"] = billto_ids[:5]
 
-                        def deselect_all_ids() -> None:
-                            st.session_state["customer_ids"] = []
+                            def deselect_all_ids() -> None:
+                                st.session_state["customer_ids"] = []
 
-                        st.multiselect(
-                            "Customer ID",
-                            billto_ids,
-                            key="customer_ids",
-                            max_selections=5,
-                        )
-                        btn_col1, btn_col2 = st.columns(2)
-                        btn_col1.button("Select all", on_click=select_all_ids)
-                        btn_col2.button("Deselect all", on_click=deselect_all_ids)
+                            st.multiselect(
+                                "Customer ID",
+                                billto_ids,
+                                key="customer_ids",
+                                max_selections=5,
+                            )
+                            btn_col1, btn_col2 = st.columns(2)
+                            btn_col1.button("Select all", on_click=select_all_ids)
+                            btn_col2.button("Deselect all", on_click=deselect_all_ids)
                     else:
                         st.warning("No customers found for selected operation.")
                 else:

--- a/tests/test_auto_select_customer_id.py
+++ b/tests/test_auto_select_customer_id.py
@@ -1,0 +1,29 @@
+import pytest
+from tests.test_customer_required import DummyStreamlit, run_app
+
+SINGLE_CUSTOMER = [
+    {
+        "CLIENT_SCAC": "ADSJ",
+        "BILLTO_ID": "1",
+        "BILLTO_NAME": "Acme",
+        "BILLTO_TYPE": "T",
+        "OPERATIONAL_SCAC": "ADSJ",
+    }
+]
+
+
+def test_auto_select_single_customer_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    def selectbox(self, label, options, index=0, key=None, **k):
+        choice = options[0] if options else None
+        if key:
+            self.session_state[key] = choice
+        return choice
+
+    def multiselect(self, *a, **k):
+        pytest.fail("st.multiselect should not be called")
+
+    monkeypatch.setattr(DummyStreamlit, "selectbox", selectbox)
+    monkeypatch.setattr(DummyStreamlit, "multiselect", multiselect)
+
+    st = run_app(monkeypatch, SINGLE_CUSTOMER)
+    assert st.session_state.get("customer_ids") == ["1"]

--- a/tests/test_customer_required.py
+++ b/tests/test_customer_required.py
@@ -118,6 +118,9 @@ class DummyStreamlit:
     def error(self, msg, *a, **k):
         self.errors.append(msg)
 
+    def stop(self):
+        return None
+
     def columns(self, n):
         return (DummyContainer(),) * n
 
@@ -163,6 +166,15 @@ def test_pit_bid_requires_customer_id(monkeypatch):
         return choice
 
     monkeypatch.setattr(DummyStreamlit, "selectbox", selectbox)
-    st = run_app(monkeypatch, CUSTOMERS)
+    customers = CUSTOMERS + [
+        {
+            "CLIENT_SCAC": "ADSJ",
+            "BILLTO_ID": "2",
+            "BILLTO_NAME": "Acme",
+            "BILLTO_TYPE": "T",
+            "OPERATIONAL_SCAC": "ADSJ",
+        }
+    ]
+    st = run_app(monkeypatch, customers)
     assert "Select at least one Customer ID." in st.errors
     assert "Customer ID" in st.multiselect_calls


### PR DESCRIPTION
## Summary
- Auto-select the sole customer ID for PIT BID templates instead of rendering a multiselect
- Add regression test verifying the automatic selection logic
- Adjust customer ID requirement test and dummy Streamlit to support new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cc52662088333ae36ac89d5a14897