### PR TITLE
Show CSV preview before export download

### DIFF
--- a/app.py
+++ b/app.py
@@ -458,6 +458,14 @@ def main():
             csv_data = st.session_state.get("mapped_csv")
 
             if csv_data:
+                import pandas as pd
+                import io
+
+                preview_df = pd.read_csv(io.BytesIO(csv_data))
+                if hasattr(st, "dataframe"):
+                    st.dataframe(preview_df.head())
+                else:  # pragma: no cover - fallback for test stubs
+                    st.write(preview_df.head())
                 st.download_button(
                     "Download mapped CSV",
                     data=csv_data,


### PR DESCRIPTION
## Summary
- Load exported CSV bytes into a DataFrame
- Preview the first rows with `st.dataframe` before download
- Support environments lacking `st.dataframe` via fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689cdc7f58b88333a0ae9d14ec1b73d0