### PR TITLE
Hide layer confirmation message after export

### DIFF
--- a/app.py
+++ b/app.py
@@ -347,8 +347,6 @@ def main():
                 st.stop()
 
         # All layers confirmed - run export step
-        st.success("✅ All layers confirmed! Proceed to export.")
-
         last_idx = len(template_obj.layers) - 1
         if st.button("Back to mappings"):
             for key in [
@@ -361,6 +359,7 @@ def main():
             st.rerun()
 
         if not st.session_state.get("export_complete"):
+            st.success("✅ All layers confirmed! Proceed to export.")
             st.header("Step — Run Export")
             if st.button("Run Export"):
                 with st.spinner("Gathering mileage and toll data…"):


### PR DESCRIPTION
## Summary
- remove lingering "All layers confirmed" alert once export begins

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas streamlit pydantic openai` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_689ce5f685888333b4e12716b84e6651