### PR TITLE
Parameterize export step labels

### DIFF
--- a/app.py
+++ b/app.py
@@ -362,7 +362,12 @@ def main():
             st.rerun()
 
         if not st.session_state.get("export_complete"):
-            st.header("Step — Run Export")
+            header_text: str = "Step — Run Export"
+            button_text: str = "Run Export"
+            if template_obj.template_name == "PIT BID":
+                header_text = "Step 2 - Generate BID File"
+                button_text = "Generate BID"
+            st.header(header_text)
 
             sheet = st.session_state.get("upload_sheet", 0)
             df, _ = read_tabular_file(
@@ -378,7 +383,7 @@ def main():
             tmp_path.unlink()
             st.dataframe(mapped_df)
 
-            if st.button("Run Export"):
+            if st.button(button_text):
                 with st.spinner("Gathering mileage and toll data…"):
                     sheet = st.session_state.get("upload_sheet", 0)
                     df, _ = read_tabular_file(

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -102,7 +102,7 @@ def setup_header_env(monkeypatch: MonkeyPatch) -> HeaderDummyStreamlit:
 
 
 def run_app_with_labels(monkeypatch: MonkeyPatch) -> Tuple[Dict[str, object], Dict[str, object]]:
-    st = DummyStreamlit([{"Run Export"}])
+    st = DummyStreamlit([{"Generate BID"}])
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setenv("DISABLE_AUTH", "1")
     monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -120,7 +120,7 @@ class DummyStreamlit:
 
 
 def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
-    st = DummyStreamlit(button_sequence or [{"Run Export"}])
+    st = DummyStreamlit(button_sequence or [{"Generate BID"}])
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setenv("DISABLE_AUTH", "1")
     monkeypatch.setenv("CLIENT_DEST_SITE", "https://tenant.sharepoint.com/sites/demo")
@@ -221,7 +221,7 @@ def test_back_before_export(monkeypatch):
 def test_back_after_export(monkeypatch):
     _, state, _ = run_app(
         monkeypatch,
-        button_sequence=[{"Run Export"}, {"Back to mappings"}],
+        button_sequence=[{"Generate BID"}, {"Back to mappings"}],
     )
     for key in ["export_complete", "mapped_csv"]:
         assert key not in state


### PR DESCRIPTION
## Summary
- vary export step header/button based on template name
- update tests for PIT BID-specific button label

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ce8f116088333ab667b34dafe48b2