### PR TITLE
Show custom adhoc headers in export preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -380,7 +380,9 @@ def main():
                 tmp_path = Path(tmp.name)
                 mapped_df = save_mapped_csv(df, preview_json, tmp_path)
             tmp_path.unlink()
-            st.dataframe(mapped_df)
+            adhoc_headers = st.session_state.get("header_adhoc_headers", {})
+            display_df = mapped_df.rename(columns=adhoc_headers)
+            st.dataframe(display_df)
 
             if st.button(button_text):
                 with st.spinner("Gathering mileage and toll data…"):

--- a/tests/test_preview_pipeline.py
+++ b/tests/test_preview_pipeline.py
@@ -27,3 +27,27 @@ def test_preview_pipeline(tmp_path: Path) -> None:
     assert list(mapped_df.columns) == ["Name", "Value"]
     assert mapped_df.iloc[0]["Value"] == 1
 
+
+def test_preview_pipeline_custom_label(tmp_path: Path) -> None:
+    template = Template.model_validate(
+        json.loads(Path("tests/fixtures/simple-template.json").read_text())
+    )
+    with open("tests/fixtures/simple.csv", "rb") as f:
+        df, _ = read_tabular_file(f)
+    state = {
+        "header_mapping_0": {
+            "Name": {"src": "Name"},
+            "ADHOC_INFO1": {"src": "Value"},
+        },
+        "header_extra_fields_0": ["ADHOC_INFO1"],
+        "header_adhoc_headers": {"ADHOC_INFO1": "Custom"},
+    }
+    preview_json = build_output_template(template, state, "dummy-guid")
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+        mapped_df = save_mapped_csv(df, preview_json, tmp_path)
+    tmp_path.unlink()
+    adhoc_headers = state["header_adhoc_headers"]
+    display_df = mapped_df.rename(columns=adhoc_headers)
+    assert list(display_df.columns) == ["Name", "Value", "Custom"]
+


### PR DESCRIPTION
## Summary
- Preview DataFrame now displays custom adhoc header labels
- Test ensures preview honors `header_adhoc_headers`

## Testing
- `pytest tests/test_preview_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689ceec6d6c883339eb377b41deedba3