### PR TITLE
feat: add sharepoint link for pit bid

### DIFF
--- a/app.py
+++ b/app.py
@@ -426,7 +426,7 @@ def main():
                         template_obj.template_guid,
                         adhoc_headers,
                     )
-                    run_postprocess_if_configured(
+                    _, payload = run_postprocess_if_configured(
                         template_obj,
                         df,
                         guid,
@@ -440,6 +440,7 @@ def main():
                         {
                             "export_complete": True,
                             "mapped_csv": csv_bytes,
+                            "postprocess_payload": payload,
                         }
                     )
                     st.rerun()
@@ -447,6 +448,12 @@ def main():
             st.success(
                 "Your PIT is being created and will be uploaded to your SharePoint site in ~5 minutes."
             )
+            payload = st.session_state.get("postprocess_payload") or {}
+            dest_site = payload.get("CLIENT_DEST_SITE")
+            dest_path = payload.get("CLIENT_DEST_FOLDER_PATH")
+            if dest_site and dest_path:
+                sharepoint_url = f"{dest_site.rstrip('/')}{dest_path}"
+                st.markdown(f"[Open SharePoint folder]({sharepoint_url})")
             csv_data = st.session_state.get("mapped_csv")
 
             if csv_data:

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -159,6 +159,7 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
         payload = {
             "p": 1,
             "CLIENT_DEST_SITE": "https://tenant.sharepoint.com/sites/demo",
+            "CLIENT_DEST_FOLDER_PATH": "/docs/folder",
             "DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
         }
         return ["ok"], payload
@@ -206,10 +207,13 @@ def test_postprocess_runner_called(monkeypatch):
     assert "final_json" not in state
 
 
-def test_no_sharepoint_link_displayed(monkeypatch):
+def test_sharepoint_link_displayed(monkeypatch):
     _, _, st = run_app(monkeypatch)
     assert any("mileage and toll data" in m for m in st.spinner_messages)
-    assert not st.markdown_calls
+    assert any(
+        "https://tenant.sharepoint.com/sites/demo/docs/folder" in m
+        for m in st.markdown_calls
+    )
 
 
 def test_back_before_export(monkeypatch):


### PR DESCRIPTION
## Summary
- show link to SharePoint folder after PIT bid postprocess
- cover SharePoint link rendering in wizard postprocess tests

## Testing
- `pytest` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_689d24c287e48333baa40869c26e0d45