### PR TITLE
Persist and render export preview in session state

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,7 @@ def main():
             "export_complete",
             "customer_name",
             "selected_customer",
+            "mapped_preview_df",
         ]:
             st.session_state.pop(k, None)
         st.session_state["upload_data_file"] = None
@@ -355,6 +356,7 @@ def main():
             for key in [
                 "export_complete",
                 "mapped_csv",
+                "mapped_preview_df",
             ]:
                 st.session_state.pop(key, None)
             st.session_state.pop(f"layer_confirmed_{last_idx}", None)
@@ -384,6 +386,7 @@ def main():
             tmp_path.unlink()
             adhoc_headers = st.session_state.get("header_adhoc_headers", {})
             display_df = mapped_df.rename(columns=adhoc_headers)
+            st.session_state["mapped_preview_df"] = display_df
             st.dataframe(display_df)
 
             if st.button(button_text):
@@ -454,6 +457,9 @@ def main():
             if dest_site and dest_path:
                 sharepoint_url = f"{dest_site.rstrip('/')}{dest_path}"
                 st.markdown(f"[Open SharePoint folder]({sharepoint_url})")
+            preview_df = st.session_state.get("mapped_preview_df")
+            if preview_df is not None:
+                st.dataframe(preview_df)
             csv_data = st.session_state.get("mapped_csv")
 
             if csv_data:

--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -177,7 +177,7 @@ def _connect() -> "pyodbc.Connection":
     try:
         import pyodbc  # type: ignore
     except ImportError as exc:
-        raise RuntimeError("pyodbc not installed") from exc
+        raise RuntimeError("pyodbc import failed") from exc
 
     # Explicit connection string still wins if you provide one.
     user_conn_str = os.getenv("AZURE_SQL_CONN_STRING")
@@ -185,7 +185,7 @@ def _connect() -> "pyodbc.Connection":
         return pyodbc.connect(user_conn_str)
 
     # Probe available ODBC drivers and pick the best Microsoft one.
-    drivers = pyodbc.drivers()
+    drivers = getattr(pyodbc, "drivers", lambda: [])()
     drivers_lower = [d.lower() for d in drivers]
     if "odbc driver 18 for sql server" in drivers_lower:
         driver_name = "ODBC Driver 18 for SQL Server"


### PR DESCRIPTION
## Summary
- cache mapping preview in Streamlit session state and display after postprocess
- clear preview state on reset
- handle missing pyodbc drivers gracefully and improve import error message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d277edcac833395b35fc621de222a