### PR TITLE
feat: skip instruction worksheets by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,14 @@ azure_sql._odbc_diag_log()
 load_dotenv()
 
 
+def default_sheet_index(sheets: list[str]) -> int:
+    """Return index of first sheet not labeled as instructions."""
+    for idx, name in enumerate(sheets):
+        if "instruction" not in name.lower():
+            return idx
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # 0. Page config & helpers
 # ---------------------------------------------------------------------------
@@ -210,10 +218,13 @@ def main():
             sheets = list_sheets(uploaded_file)
         st.session_state["upload_sheets"] = sheets
         sheet_key = "upload_sheet"
+        default_idx = default_sheet_index(sheets)
         if len(sheets) > 1:
-            st.selectbox("Select sheet", sheets, key=sheet_key)
-        else:
-            st.session_state[sheet_key] = sheets[0]
+            st.selectbox(
+                "Select sheet", sheets, index=default_idx, key=sheet_key
+            )
+        if sheet_key not in st.session_state:
+            st.session_state[sheet_key] = sheets[default_idx]
 
     if (
         st.session_state.get("uploaded_file")

--- a/tests/test_instruction_sheet_default.py
+++ b/tests/test_instruction_sheet_default.py
@@ -1,0 +1,25 @@
+import app
+
+
+def test_instruction_sheet_not_default():
+    sheets = ["Instructions", "Data"]
+    idx = app.default_sheet_index(sheets)
+    assert idx == 1
+
+    session_state: dict[str, str] = {}
+    captured: dict[str, list[str] | int] = {}
+
+    def fake_selectbox(label: str, options: list[str], index: int, key: str) -> str:
+        captured["options"] = options
+        captured["index"] = index
+        session_state[key] = options[index]
+        return options[index]
+
+    sheet_key = "upload_sheet"
+    if len(sheets) > 1:
+        fake_selectbox("Select sheet", sheets, idx, sheet_key)
+    if sheet_key not in session_state:
+        session_state[sheet_key] = sheets[idx]
+
+    assert session_state[sheet_key] == "Data"
+    assert "Instructions" in captured["options"]


### PR DESCRIPTION
## Summary
- skip instruction sheets when choosing default upload sheet
- default to next sheet when instructions tab is first
- add regression test for instruction sheet selection

## Testing
- `pytest tests/test_instruction_sheet_default.py -q`
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'drivers')*


------
https://chatgpt.com/codex/tasks/task_b_689d280968a08333bcb0abbafc0a1a5f