### PR TITLE
Use container for customer ID buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -310,9 +310,30 @@ def main():
                                 key="customer_ids",
                                 max_selections=5,
                             )
-                            btn_col1, btn_col2 = st.columns(2)
-                            btn_col1.button("Select all", on_click=select_all_ids)
-                            btn_col2.button("Deselect all", on_click=deselect_all_ids)
+                            with st.container():
+                                btn_col1, btn_col2 = st.columns([1, 1])
+                                btn_col1.button(
+                                    "Select all",
+                                    on_click=select_all_ids,
+                                    key="cid_select_all",
+                                )
+                                btn_col2.button(
+                                    "Deselect all",
+                                    on_click=deselect_all_ids,
+                                    key="cid_clear_all",
+                                )
+                                st.markdown(
+                                    """
+                                    <style>
+                                    div[data-testid="stButton"]#cid_select_all button,
+                                    div[data-testid="stButton"]#cid_clear_all button {
+                                        padding: 0.25rem 0.5rem;
+                                        border: 1px solid #d4d4d4;
+                                    }
+                                    </style>
+                                    """,
+                                    unsafe_allow_html=True,
+                                )
                     else:
                         st.warning("No customers found for selected operation.")
                 else:

--- a/tests/test_customer_required.py
+++ b/tests/test_customer_required.py
@@ -119,6 +119,9 @@ class DummyStreamlit:
     def spinner(self, *a, **k):
         return DummyContainer()
 
+    def container(self) -> DummyContainer:
+        return DummyContainer()
+
     def empty(self):
         return DummyContainer()
 

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -118,6 +118,9 @@ class DummyStreamlit:
         n = len(spec) if isinstance(spec, (list, tuple)) else spec
         return [DummyColumn() for _ in range(n)]
 
+    def container(self) -> DummyContainer:
+        return DummyContainer()
+
 
 def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     st = DummyStreamlit(button_sequence or [{"Generate BID"}])


### PR DESCRIPTION
## Summary
- Wrap customer ID select/deselect buttons in a Streamlit container and use columns for layout
- Add keys and CSS styling to integrate buttons with multiselect
- Extend test stubs with a `container` method to support new UI code

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d5ac966e08333b6ed14bcef51b576