### PR TITLE
Use helper for required labels across Streamlit UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ from app_utils.ui_utils import (
     render_progress,
     set_steps_from_template,
     compute_current_step,
+    render_required_label,
 )
 from app_utils.excel_utils import list_sheets, read_tabular_file, save_mapped_csv
 from app_utils.postprocess_runner import run_postprocess_if_configured
@@ -149,14 +150,21 @@ def main():
         op_idx = 0
         if st.session_state.get("operation_code") in op_codes:
             op_idx = op_codes.index(st.session_state["operation_code"])
-        st.selectbox("Operation Code:", op_codes, index=op_idx, key="operation_code")
+        render_required_label("Operation Code")
+        st.selectbox(
+            "Operation Code",
+            op_codes,
+            index=op_idx,
+            key="operation_code",
+            label_visibility="collapsed",
+        )
         st.session_state["operational_scac"] = get_operational_scac(
             st.session_state["operation_code"]
         )
 
         st.subheader("Select Template")
         template_files = sorted(p.name for p in TEMPLATES_DIR.glob("*.json"))
-
+        render_required_label("Template JSON")
         selected_file = st.selectbox(
             "Template JSON",
             options=template_files,
@@ -165,6 +173,7 @@ def main():
                 if st.session_state.get("selected_template_file") in template_files
                 else 0 if template_files else None
             ),
+            label_visibility="collapsed",
         )
 
         template_obj: Template | None = None
@@ -208,10 +217,12 @@ def main():
     # 3. Upload client data file
     # ---------------------------------------------------------------------------
 
+    render_required_label("Upload client data file (Excel or CSV)")
     uploaded_file = st.file_uploader(
         "Upload client data file (Excel or CSV)",
         type=["csv", "xls", "xlsx"],
         key="upload_data_file",
+        label_visibility="collapsed",
     )
     if uploaded_file:
         st.session_state["uploaded_file"] = uploaded_file
@@ -221,8 +232,13 @@ def main():
         sheet_key = "upload_sheet"
         default_idx = default_sheet_index(sheets)
         if len(sheets) > 1:
+            render_required_label("Select sheet")
             st.selectbox(
-                "Select sheet", sheets, index=default_idx, key=sheet_key
+                "Select sheet",
+                sheets,
+                index=default_idx,
+                key=sheet_key,
+                label_visibility="collapsed",
             )
         if sheet_key not in st.session_state:
             st.session_state[sheet_key] = sheets[default_idx]
@@ -272,12 +288,14 @@ def main():
                     if prev_name_norm in cust_names
                     else None
                 )
+                render_required_label("Customer")
                 selected_name = st.selectbox(
                     "Customer",
                     cust_names,
                     index=idx,
                     key="customer_name",
                     placeholder="Select a customer",
+                    label_visibility="collapsed",
                 )
                 if selected_name and selected_name != prev_name_norm:
                     st.session_state["customer_ids"] = []
@@ -304,11 +322,13 @@ def main():
                             def deselect_all_ids() -> None:
                                 st.session_state["customer_ids"] = []
 
+                            render_required_label("Customer ID")
                             st.multiselect(
                                 "Customer ID",
                                 billto_ids,
                                 key="customer_ids",
                                 max_selections=5,
+                                label_visibility="collapsed",
                             )
                             btn_col1, btn_col2 = st.columns(2)
                             btn_col1.button("Select all", on_click=select_all_ids)

--- a/app_utils/ui_utils.py
+++ b/app_utils/ui_utils.py
@@ -138,3 +138,13 @@ def render_progress(container: st.delta_generator.DeltaGenerator | None = None) 
                     f'<div class="step todo">{step}</div>', unsafe_allow_html=True
                 )
         st.markdown('</div>', unsafe_allow_html=True)
+
+
+# ---------------------------------------------------------------------------
+# 3. Field label helpers
+# ---------------------------------------------------------------------------
+
+
+def render_required_label(text: str) -> None:
+    """Render a field label with a red asterisk."""
+    st.markdown(f"{text} <span style='color:red'>*</span>", unsafe_allow_html=True)

--- a/pages/steps/computed.py
+++ b/pages/steps/computed.py
@@ -6,6 +6,7 @@ import streamlit as st
 from app_utils.excel_utils import read_tabular_file
 from app_utils.mapping.computed_layer import gpt_formula_suggestion
 from app_utils.ui.expression_builder import build_expression
+from app_utils.ui_utils import render_required_label
 from schemas.template_v2 import Template
 
 
@@ -42,6 +43,7 @@ def render(layer, idx: int):
 
     # 2A. Direct mapping UI
     if mode.startswith("Direct") and strategy != "user_defined":
+        render_required_label("Select source column")
         col = st.selectbox(
             "Select source column",
             options=[""] + list(df.columns),
@@ -50,6 +52,7 @@ def render(layer, idx: int):
                 if result.get("source_cols")
                 else 0
             ),
+            label_visibility="collapsed",
         )
 
         if col:

--- a/pages/template_manager.py
+++ b/pages/template_manager.py
@@ -20,7 +20,11 @@ from app_utils.template_builder import (
     apply_field_choices,
     gpt_field_suggestions,
 )
-from app_utils.ui_utils import render_progress, compute_current_step
+from app_utils.ui_utils import (
+    render_progress,
+    compute_current_step,
+    render_required_label,
+)
 
 
 def persist_template(tpl: dict) -> str:
@@ -52,11 +56,12 @@ def show() -> None:
     # Create new template from sample file
     # ------------------------------------------------------------------
     st.header("Create New Template")
-
+    render_required_label("Upload CSV/Excel sample or Template JSON")
     uploaded = st.file_uploader(
         "Upload CSV/Excel sample or Template JSON",
         type=["csv", "xls", "xlsx", "xlsm", "json"],
         key="tm_file",
+        label_visibility="collapsed",
     )
     if uploaded is not None:
         if uploaded.name.lower().endswith(".json"):
@@ -71,12 +76,23 @@ def show() -> None:
             except Exception as e:  # noqa: BLE001
                 st.error(f"Failed to read JSON: {e}")
         else:
-            st.text_input("Template Name", key="tm_name")
+            render_required_label("Template Name")
+            st.text_input(
+                "Template Name",
+                key="tm_name",
+                label_visibility="collapsed",
+            )
             with st.spinner("Loading file..."):
                 sheets = list_sheets(uploaded)
             sheet_key = "tm_sheet"
             if len(sheets) > 1:
-                sheet = st.selectbox("Select sheet", sheets, key=sheet_key)
+                render_required_label("Select sheet")
+                sheet = st.selectbox(
+                    "Select sheet",
+                    sheets,
+                    key=sheet_key,
+                    label_visibility="collapsed",
+                )
             else:
                 sheet = sheets[0]
                 st.session_state[sheet_key] = sheet

--- a/tests/test_computed_page.py
+++ b/tests/test_computed_page.py
@@ -28,8 +28,11 @@ class DummyStreamlit:
     def radio(self, label, options, key=None):  # noqa: D401 - doc string not needed
         return options[0]
 
-    def selectbox(self, label, options, index=0, key=None):
+    def selectbox(self, label, options, index=0, key=None, **k):
         return options[index]
+
+    def markdown(self, *a, **k):
+        pass
 
     def button(self, *a, **k):
         return False


### PR DESCRIPTION
## Summary
- add `render_required_label` helper to generate red-asterisk field labels
- apply helper to operation code, template, file upload, customer selections and Template Manager form
- update computed step test stub for new widget API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d5abf6af083339127eaee486d1535