### PR TITLE
feat: apply global spacing styles

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from app_utils.ui_utils import (
     set_steps_from_template,
     compute_current_step,
     render_required_label,
+    apply_global_css,
 )
 from app_utils.excel_utils import list_sheets, read_tabular_file, save_mapped_csv
 from app_utils.postprocess_runner import run_postprocess_if_configured
@@ -70,6 +71,7 @@ def default_sheet_index(sheets: list[str]) -> int:
 @require_login
 def main():
     st.set_page_config(page_title="AI Mapping Agent", layout="wide")
+    apply_global_css()
     st.title("AI Mapping Agent")
 
     if st.session_state.get("unsaved_changes"):

--- a/app_utils/ui_utils.py
+++ b/app_utils/ui_utils.py
@@ -19,6 +19,28 @@ import streamlit as st
 from typing import List
 
 # ---------------------------------------------------------------------------
+# 0. Global CSS helpers
+# ---------------------------------------------------------------------------
+
+
+def apply_global_css() -> None:
+    """Inject shared spacing and layout tweaks."""
+    st.markdown(
+        """
+        <style>
+        :root { --gap: 10px; --card-pad: 14px; --card-radius: 10px; }
+        .block-container { padding-top: 12px; }
+        [data-testid="stVerticalBlock"] { gap: var(--gap) !important; }
+        .section-card { border:1px solid rgba(255,255,255,.08); border-radius:var(--card-radius); padding:var(--card-pad); margin-bottom:14px; background:rgba(255,255,255,.02); }
+        .compact [data-testid="stSelectbox"] { max-width: 460px; }
+        .button-row { display:flex; gap:8px; flex-wrap:wrap; }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+# ---------------------------------------------------------------------------
 # 1. Dynamic step handling
 # ---------------------------------------------------------------------------
 

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -1,0 +1,7 @@
+"""Shared initialization for Streamlit pages."""
+
+from __future__ import annotations
+
+from app_utils.ui_utils import apply_global_css
+
+apply_global_css()


### PR DESCRIPTION
## Summary
- add helper to inject global CSS spacing tweaks
- apply spacing utility across all Streamlit pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_689d6ce207448333945539fdcd7542f5