### PR TITLE
feat: allow adding customers from PIT BID

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -261,6 +261,22 @@ def fetch_customers(operational_scac: str) -> List[Dict[str, str]]:
     return sorted(rows, key=lambda r: r["BILLTO_NAME"])
 
 
+def insert_customer(client_scac: str, name: str, billto_id: str | None = None) -> None:
+    """Insert a customer record."""
+    try:
+        conn = _connect()
+    except RuntimeError as err:  # pragma: no cover - exercised in integration
+        raise RuntimeError(f"Customer insert failed: {err}") from err
+    with conn:
+        conn.cursor().execute(
+            (
+                "INSERT INTO dbo.SPOQ_BILLTO_XREF "
+                "(CLIENT_SCAC, BILLTO_NAME, BILLTO_ID) VALUES (?, ?, ?)"
+            ),
+            (client_scac, name, billto_id),
+        )
+
+
 def fetch_freight_type(operation_cd: str) -> str | None:
     """Return the default freight type for an operation code."""
     try:

--- a/app_utils/ui/customer_dialog.py
+++ b/app_utils/ui/customer_dialog.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+"""Modal dialog for creating a new customer."""
+
+import streamlit as st
+
+from app_utils.azure_sql import fetch_customers, insert_customer
+
+
+def open_new_customer_dialog(client_scac: str, operational_scac: str) -> None:
+    """Open modal to add a customer and refresh list on save."""
+
+    @st.dialog("Add Customer", width="small")
+    def _dialog() -> None:
+        name = st.text_input("Customer Name")
+        billto_id = st.text_input("Customer ID")
+        if st.button("💾 Save", disabled=not name.strip()):
+            try:
+                insert_customer(client_scac, name.strip(), billto_id.strip() or None)
+            except Exception as err:  # pragma: no cover - UI feedback only
+                st.error(f"Failed to add customer: {err}")
+                return
+            customers = fetch_customers(operational_scac)
+            st.session_state["customer_options"] = customers
+            if customers:
+                st.session_state["client_scac"] = customers[0]["CLIENT_SCAC"]
+            st.session_state["customer_name"] = name.strip().title()
+            st.session_state["customer_ids"] = (
+                [billto_id.strip()] if billto_id.strip() else []
+            )
+            st.rerun()
+
+    _dialog()

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -128,6 +128,31 @@ def test_fetch_customers(monkeypatch):
     assert [c["BILLTO_NAME"] for c in customers] == ["Alpha", "Beta"]
 
 
+def test_insert_customer(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeCursor:
+        def execute(self, query, params):  # pragma: no cover - executed via call
+            captured["query"] = query
+            captured["params"] = params
+            return self
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(azure_sql, "_connect", lambda: FakeConn())
+    azure_sql.insert_customer("ADSJ", "NewCo", "123")
+    assert "INSERT INTO" in captured["query"]
+    assert captured["params"] == ("ADSJ", "NewCo", "123")
+
+
 def test_connect_requires_config(monkeypatch):
     original_import = builtins.__import__
 

--- a/tests/test_customer_grouping.py
+++ b/tests/test_customer_grouping.py
@@ -154,5 +154,5 @@ def run_app(monkeypatch):
 
 def test_customer_grouping(monkeypatch):
     st = run_app(monkeypatch)
-    assert st.customer_options == ["Boise Cascade"]
+    assert st.customer_options == ["Boise Cascade", "+ New Customer"]
     assert "customer_id_options" not in st.session_state

--- a/tests/test_customer_required.py
+++ b/tests/test_customer_required.py
@@ -139,9 +139,9 @@ class DummyStreamlit:
     def stop(self):
         return None
 
-    def columns(self, n):
+    def columns(self, n, **kwargs):
         count = n if isinstance(n, int) else len(n)
-        return (self,) * count
+        return (DummyContainer(),) * count
 
     def rerun(self):
         pass

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -17,6 +17,12 @@ class DummyContainer:
 
 
 class DummyColumn:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
     def button(self, *a, **k):
         return False
 
@@ -114,7 +120,7 @@ class DummyStreamlit:
         if key:
             self.session_state[key] = sel
         return sel
-    def columns(self, spec):
+    def columns(self, spec, **kwargs):
         n = len(spec) if isinstance(spec, (list, tuple)) else spec
         return [DummyColumn() for _ in range(n)]
 
@@ -140,7 +146,13 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     )
     monkeypatch.setattr(
         "app_utils.azure_sql.fetch_customers",
-        lambda scac: [{"BILLTO_NAME": "Cust", "BILLTO_ID": "1"}],
+        lambda scac: [
+            {
+                "CLIENT_SCAC": "ADSJ",
+                "BILLTO_NAME": "Cust",
+                "BILLTO_ID": "1",
+            }
+        ],
     )
     monkeypatch.setattr(
         "app_utils.azure_sql.insert_pit_bid_rows",


### PR DESCRIPTION
## Summary
- allow PIT BID users to add a customer via "+ New Customer" option and modal
- support customer insertion into Azure SQL
- test customer creation and update dummy UI helpers for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dfb0bdc208333a7cc75d69abbb171