### PR TITLE
Allow optional customer IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -301,11 +301,23 @@ def main():
                 c for c in st.session_state["customer_options"] if c["BILLTO_NAME"]
             ]
             st.session_state["customer_options"] = cust_records
-            cust_names = sorted({c["BILLTO_NAME"] for c in cust_records})
+            seen_names: set[str] = set()
+            cust_names: list[str] = []
+            for c in cust_records:
+                name = c["BILLTO_NAME"]
+                norm = name.strip().lower()
+                if norm not in seen_names:
+                    seen_names.add(norm)
+                    cust_names.append(name.title())
             if cust_names:
                 cust_names.append("+ New Customer")
                 prev_name = st.session_state.get("customer_name")
-                idx = cust_names.index(prev_name) if prev_name in cust_names else None
+                prev_name_norm = prev_name.title() if prev_name else None
+                idx = (
+                    cust_names.index(prev_name_norm)
+                    if prev_name_norm in cust_names
+                    else None
+                )
                 try:
                     cust_col, _ = st.columns([3, 1])
                 except TypeError:
@@ -521,7 +533,7 @@ def main():
                         mapped_df,
                         st.session_state["operation_code"],
                         st.session_state["customer_name"],
-                        st.session_state["customer_ids"],
+                        st.session_state.get("customer_ids"),
                         guid,
                         adhoc_headers,
                     )

--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -452,7 +452,7 @@ def insert_pit_bid_rows(
     df: pd.DataFrame,
     operation_cd: str,
     customer_name: str,
-    customer_ids: Sequence[str],
+    customer_ids: Sequence[str] | None = None,
     process_guid: str | None = None,
     adhoc_headers: Dict[str, str] | None = None,
     *,
@@ -466,11 +466,12 @@ def insert_pit_bid_rows(
     Each field is mapped explicitly to its target database column via
     ``PIT_BID_FIELD_MAP``. Columns that remain unmapped are stored sequentially
     in ``ADHOC_INFO1`` … ``ADHOC_INFO10``.
-    ``customer_name`` and ``customer_ids`` are required and applied to every
-    inserted row regardless of any ``CUSTOMER_NAME`` or ``CUSTOMER_ID`` column
-    in ``df``. ``customer_ids`` may contain up to five entries. ``adhoc_headers``
-    maps ``ADHOC_INFO`` slot names to their source column headers. It is
-    currently unused but accepted so callers can persist the mapping via
+    ``customer_name`` is required and applied to every inserted row regardless
+    of any ``CUSTOMER_NAME`` column in ``df``. ``customer_ids`` may be ``None``
+    or contain up to five entries. If ``customer_ids`` is ``None`` or an empty
+    sequence, ``CUSTOMER_ID`` is inserted as ``NULL``. ``adhoc_headers`` maps
+    ``ADHOC_INFO`` slot names to their source column headers. It is currently
+    unused but accepted so callers can persist the mapping via
     :func:`log_mapping_process`.
     """
     base_columns = [
@@ -567,7 +568,7 @@ def insert_pit_bid_rows(
     else:
         default_freight = fetch_freight_type(operation_cd)
 
-    ids = list(customer_ids)
+    ids = list(customer_ids or [])
     if len(ids) > 5:
         raise ValueError("Up to 5 customer IDs supported")
 

--- a/cli.py
+++ b/cli.py
@@ -101,8 +101,6 @@ def main() -> None:
     template = load_template(args.template)
     if template.template_name == "PIT BID" and not args.customer_name:
         parser.error("--customer-name is required for PIT BID templates")
-    if template.template_name == "PIT BID" and not args.customer_ids:
-        parser.error("At least one --customer-id is required for PIT BID templates")
     df = load_data(args.input_file)
     state = auto_map(template, df)
     process_guid = str(uuid.uuid4())
@@ -118,7 +116,6 @@ def main() -> None:
         if (
             args.operation_code
             and args.customer_name
-            and args.customer_ids
             and template.template_name == "PIT BID"
         ):
             rows = azure_sql.insert_pit_bid_rows(

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -302,6 +302,29 @@ def test_insert_pit_bid_rows_blanks(monkeypatch):
     assert captured["params"][25] is None  # RFP_MILES
 
 
+def test_insert_pit_bid_rows_no_ids(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
+    monkeypatch.setattr(azure_sql, "fetch_freight_type", lambda op: None)
+    df = pd.DataFrame(
+        {
+            "Lane ID": ["L1"],
+            "Origin City": ["OC"],
+            "Orig State": ["OS"],
+            "Orig Zip (5 or 3)": ["11111"],
+            "Destination City": ["DC"],
+            "Dest State": ["DS"],
+            "Dest Zip (5 or 3)": ["22222"],
+            "Bid Volume": [5],
+            "LH Rate": [1.2],
+            "Bid Miles": [100],
+        }
+    )
+    rows = azure_sql.insert_pit_bid_rows(df, "OP", "Customer", None, "guid")
+    assert rows == 1
+    assert captured["params"][2] is None  # CUSTOMER_ID
+
+
 def test_insert_pit_bid_rows_with_db_columns(monkeypatch):
     captured = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))

--- a/tests/test_customer_grouping.py
+++ b/tests/test_customer_grouping.py
@@ -98,6 +98,9 @@ class DummyStreamlit:
     def spinner(self, *a: Any, **k: Any) -> DummyContainer:
         return DummyContainer()
 
+    def container(self) -> DummyContainer:
+        return DummyContainer()
+
     def empty(self) -> DummyContainer:
         return DummyContainer()
 


### PR DESCRIPTION
## Summary
- permit `insert_pit_bid_rows` to accept no customer IDs and insert `NULL`
- update app and CLI to handle missing customer IDs and normalize customer names
- add tests for inserting with and without customer IDs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dfee5687c8333b39f0ee5a4308284