### PR TITLE
Allow PIT BID templates without customer IDs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -84,7 +84,10 @@ def main() -> None:
         dest="customer_ids",
         action="append",
         default=[],
-        help="Customer ID(s) for SQL insert (repeatable or comma-separated, up to 5)",
+        help=(
+            "Customer ID(s) for SQL insert (repeatable or comma-separated, up to 5). "
+            "Required only if the chosen customer has IDs"
+        ),
     )
     parser.add_argument(
         "--user-email",
@@ -101,8 +104,6 @@ def main() -> None:
     template = load_template(args.template)
     if template.template_name == "PIT BID" and not args.customer_name:
         parser.error("--customer-name is required for PIT BID templates")
-    if template.template_name == "PIT BID" and not args.customer_ids:
-        parser.error("At least one --customer-id is required for PIT BID templates")
     df = load_data(args.input_file)
     state = auto_map(template, df)
     process_guid = str(uuid.uuid4())
@@ -118,7 +119,6 @@ def main() -> None:
         if (
             args.operation_code
             and args.customer_name
-            and args.customer_ids
             and template.template_name == "PIT BID"
         ):
             rows = azure_sql.insert_pit_bid_rows(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import json
 from pathlib import Path
 import sys
 
@@ -163,8 +164,6 @@ def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path, capsys):
         'OP',
         '--customer-name',
         'Cust',
-        '--customer-id',
-        '1',
     ])
 
     cli.main()
@@ -204,15 +203,29 @@ def test_cli_requires_customer_name_for_pit_bid(monkeypatch, tmp_path: Path):
         cli.main()
 
 
-def test_cli_requires_customer_id_for_pit_bid(monkeypatch, tmp_path: Path):
+def test_cli_sql_insert_without_customer_id(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
     tpl = Path('templates/pit-bid.json')
     src = tmp_path / 'src.csv'
     src.write_text('Lane ID,Bid Volume\nL1,5\n')
     out_json = tmp_path / 'out.json'
     out_csv = tmp_path / 'out.csv'
 
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
+    captured: dict[str, object] = {}
+
+    def fake_insert(df, op, cust, ids, guid, adhoc_headers):
+        captured['ids'] = ids
+        return len(df)
+
+    monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
     monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
+    monkeypatch.setattr(
+        cli,
+        'run_postprocess_if_configured',
+        lambda tpl_obj, df, guid, customer_name, operation_code=None: ([], None),
+    )
+    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
     monkeypatch.setattr(sys, 'argv', [
         'cli.py',
         str(tpl),
@@ -226,6 +239,8 @@ def test_cli_requires_customer_id_for_pit_bid(monkeypatch, tmp_path: Path):
         'Cust',
     ])
 
-    with pytest.raises(SystemExit):
-        cli.main()
+    cli.main()
+    out = capsys.readouterr().out
+    assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
+    assert captured['ids'] == []
 


### PR DESCRIPTION
## Summary
- Permit PIT BID templates without customer IDs and pass empty list to downstream SQL insert
- Document conditional requirement for `--customer-id`
- Expand CLI tests for scenarios without customer IDs

## Testing
- `pytest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_b_689e014d4ea08333bdef489ad2db4567