### PR TITLE
Handle invalid user prefs file

### DIFF
--- a/app_utils/user_prefs.py
+++ b/app_utils/user_prefs.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Dict, Optional
 
 USER_PREFS_FILE = Path("data/user_prefs.json")
+logger = logging.getLogger(__name__)
 
 
 def _load() -> Dict[str, str]:
     if not USER_PREFS_FILE.exists():
         return {}
-    return json.loads(USER_PREFS_FILE.read_text())
+    try:
+        return json.loads(USER_PREFS_FILE.read_text())
+    except json.JSONDecodeError:
+        logger.warning("user prefs file %s is not valid JSON", USER_PREFS_FILE)
+        return {}
 
 
 def _save(data: Dict[str, str]) -> None:

--- a/tests/test_user_prefs.py
+++ b/tests/test_user_prefs.py
@@ -1,3 +1,5 @@
+import logging
+
 from app_utils import user_prefs
 
 
@@ -11,3 +13,21 @@ def test_set_and_get_last_template(tmp_path, monkeypatch):
 
     user_prefs.set_last_template("u@example.com", "")
     assert user_prefs.get_last_template("u@example.com") is None
+
+
+def test_load_empty_file(tmp_path, monkeypatch, caplog):
+    pref = tmp_path / "prefs.json"
+    pref.write_text("")
+    monkeypatch.setattr(user_prefs, "USER_PREFS_FILE", pref)
+
+    with caplog.at_level(logging.WARNING):
+        assert user_prefs._load() == {}
+
+
+def test_load_malformed_file(tmp_path, monkeypatch, caplog):
+    pref = tmp_path / "prefs.json"
+    pref.write_text("{ bad json }")
+    monkeypatch.setattr(user_prefs, "USER_PREFS_FILE", pref)
+
+    with caplog.at_level(logging.WARNING):
+        assert user_prefs._load() == {}


### PR DESCRIPTION
## Summary
- Prevent crashes when user prefs file is empty or malformed
- Warn when user prefs file contains invalid JSON
- Test loading behavior for empty and malformed user prefs files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e12619bf08333a41283f09ecffc0a