### PR TITLE
feat: make customer IDs optional in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -83,10 +83,10 @@ def main() -> None:
         "--customer-id",
         dest="customer_ids",
         action="append",
-        default=[],
+        default=None,
         help=(
-            "Customer ID(s) for SQL insert (repeatable or comma-separated, up to 5). "
-            "Required only if the chosen customer has IDs"
+            "Customer IDs (if any) for the selected customer. Omit for '+ New Customer' or "
+            "customers without IDs."
         ),
     )
     parser.add_argument(
@@ -97,9 +97,10 @@ def main() -> None:
     args = parser.parse_args()
 
     ids: list[str] = []
-    for value in args.customer_ids:
-        ids.extend([cid.strip() for cid in value.split(",") if cid.strip()])
-    args.customer_ids = ids
+    if args.customer_ids:
+        for value in args.customer_ids:
+            ids.extend([cid.strip() for cid in value.split(",") if cid.strip()])
+    args.customer_ids = ids or None
 
     template = load_template(args.template)
     if template.template_name == "PIT BID" and not args.customer_name:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,7 +170,7 @@ def test_cli_sql_insert_no_ids(monkeypatch, tmp_path: Path, capsys):
     out = capsys.readouterr().out
     data = json.loads(out_json.read_text())
     assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
-    assert captured['ids'] == []
+    assert captured['ids'] is None
     assert data['process_guid']
 
 def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path, capsys):
@@ -281,5 +281,5 @@ def test_cli_sql_insert_without_customer_id(
     cli.main()
     out = capsys.readouterr().out
     assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
-    assert captured['ids'] == []
+    assert captured['ids'] is None
 


### PR DESCRIPTION
## Summary
- allow running CLI without providing `--customer-id`
- clarify `--customer-id` help text
- cover runs without customer IDs in CLI tests

## Testing
- `pytest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_b_689e19a05ab08333a9941c0e9eb657b6