### PR TITLE
Handle optional customer IDs in PIT BID inserts

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,7 +268,7 @@ def main():
                 st.dataframe(df.head())
 
     customer_valid = True
-    st.session_state.setdefault("customer_ids", [])
+    st.session_state.setdefault("customer_ids", None)
 
     # ---------------------------------------------------------------------------
     # 4. Customer selection (PIT BID only)
@@ -338,7 +338,7 @@ def main():
                     customer_name = new_name.strip().title() if new_name else ""
                     st.session_state["customer_name"] = customer_name
                     st.session_state["customer_id_options"] = []
-                    st.session_state["customer_ids"] = []
+                    st.session_state["customer_ids"] = None
                     st.session_state["selected_customer"] = (
                         {"BILLTO_NAME": customer_name} if customer_name else {}
                     )
@@ -347,7 +347,7 @@ def main():
                     customer_name = selected_name
                     st.session_state["customer_name"] = customer_name
                     if selected_name and selected_name != prev_choice:
-                        st.session_state["customer_ids"] = []
+                        st.session_state["customer_ids"] = None
                 if customer_name:
                     matches = [
                         c
@@ -360,6 +360,7 @@ def main():
                             c["BILLTO_ID"]
                             for c in cust_records
                             if c["BILLTO_NAME"].strip().title() == customer_name
+                            and c.get("BILLTO_ID")
                         ]
                         st.session_state["customer_id_options"] = billto_ids
                         if billto_ids:
@@ -370,7 +371,7 @@ def main():
                                     st.session_state["customer_ids"] = billto_ids[:5]
 
                                 def deselect_all_ids() -> None:
-                                    st.session_state["customer_ids"] = []
+                                    st.session_state["customer_ids"] = None
 
                                 # Single label for both columns keeps the row visually grouped
                                 # st.markdown("**Customer ID**")
@@ -424,7 +425,7 @@ def main():
                                     )
                     else:
                         st.session_state["customer_id_options"] = []
-                        st.session_state["customer_ids"] = []
+                        st.session_state["customer_ids"] = None
                         st.info("Selected customer has no Customer IDs.")
                 else:
                     if st.session_state.get("customer_choice") != "+ New Customer":
@@ -442,7 +443,7 @@ def main():
                         st.error("Select at least one Customer ID.")
                         customer_valid = False
                 else:
-                    st.session_state["customer_ids"] = []
+                    st.session_state["customer_ids"] = None
 
     # ---------------------------------------------------------------------------
     # 5. Main wizard

--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -615,7 +615,7 @@ def insert_pit_bid_rows(
         df_db = df_db.where(pd.notna(df_db), None)
         df_db["OPERATION_CD"] = operation_cd
         df_db["CUSTOMER_NAME"] = customer_name
-        df_db["CUSTOMER_ID"] = ",".join(ids) or None
+        df_db["CUSTOMER_ID"] = ",".join(ids) if ids else None
         df_db["PROCESS_GUID"] = process_guid
         df_db["INSERTED_DTTM"] = now
         if default_freight is not None:

--- a/cli.py
+++ b/cli.py
@@ -96,11 +96,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    ids: list[str] = []
+    collected_ids: list[str] = []
     if args.customer_ids:
         for value in args.customer_ids:
-            ids.extend([cid.strip() for cid in value.split(",") if cid.strip()])
-    args.customer_ids = ids or None
+            collected_ids.extend(
+                [cid.strip() for cid in value.split(",") if cid.strip()]
+            )
+    args.customer_ids = collected_ids if collected_ids else None
 
     template = load_template(args.template)
     if template.template_name == "PIT BID" and not args.customer_name:

--- a/tests/test_customer_required.py
+++ b/tests/test_customer_required.py
@@ -207,6 +207,7 @@ def test_no_error_when_customer_has_no_ids(monkeypatch):
     st = run_app(monkeypatch, customers)
     assert st.errors == []
     assert "Customer ID" not in st.multiselect_calls
+    assert st.session_state.get("customer_ids") is None
 
 
 def test_pit_bid_requires_customer_id(monkeypatch):


### PR DESCRIPTION
## Summary
- Treat `customer_ids` as optional in PIT BID inserts and write `NULL` when none supplied
- Default `customer_ids` session state to `None` and filter out blank customer IDs in the Streamlit app
- Normalize CLI `--customer-id` arguments to `None` when missing and cover no-ID case in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e1e5e9bec83339b68a529751f747c