### PR TITLE
Remove obsolete dest path from wizard postprocess test

### DIFF
--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -175,7 +175,6 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
             "p": 1,
             "CLIENT_DEST_SITE": "https://tenant.sharepoint.com/sites/demo",
             "CLIENT_DEST_FOLDER_PATH": "/docs/folder",
-            "DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
         }
         return ["ok"], payload
 


### PR DESCRIPTION
## Summary
- remove deprecated `DEST_FOLDER_PATH` from fake postprocess runner
- keep `CLIENT_DEST_FOLDER_PATH` for SharePoint link validation

## Testing
- `pre-commit run --files tests/test_wizard_postprocess.py` *(fails: command not found)*
- `pytest tests/test_wizard_postprocess.py`


------
https://chatgpt.com/codex/tasks/task_b_689e2beb7f688333b5a7c08e0612958a