### PR TITLE
Use client destination path for PIT BID postprocess

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -75,7 +75,10 @@ def run_postprocess_if_configured(
         except RuntimeError as err:  # pragma: no cover - exercised in integration
             logs.append(f"Payload error: {err}")
             raise
-        payload["DEST_FOLDER_PATH"] = "/Client Downloads/Pricing Tools/Customer Bids"
+        payload.pop("DEST_FOLDER_PATH", None)
+        payload["CLIENT_DEST_FOLDER_PATH"] = (
+            "/Client Downloads/Pricing Tools/Customer Bids"
+        )
         logs.append("Payload loaded")
         fname = f"{operation_cd} - BID - {customer_name}.xlsm"
         payload.setdefault("item/In_dtInputData", [{}])

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -88,6 +88,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     payload = {
         "item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}],
         "BID-Payload": "",
+        "CLIENT_DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
     }
 
     monkeypatch.setattr(
@@ -120,7 +121,11 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     expected = 'OP - BID - Cust.xlsm'
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == "guid"
-    assert returned['DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert (
+        returned["CLIENT_DEST_FOLDER_PATH"]
+        == "/Client Downloads/Pricing Tools/Customer Bids"
+    )
+    assert "DEST_FOLDER_PATH" not in returned
     assert called['url'] == tpl.postprocess.url
     assert called['json'] == returned
     assert "Payload loaded" in logs
@@ -133,6 +138,7 @@ def test_pit_bid_posts(monkeypatch):
     payload = {
         "item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}],
         "BID-Payload": "",
+        "CLIENT_DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
     }
     monkeypatch.setattr(
         'app_utils.postprocess_runner.get_pit_url_payload',
@@ -168,7 +174,11 @@ def test_pit_bid_posts(monkeypatch):
     assert called['url'] == tpl.postprocess.url
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == 'guid'
-    assert returned['DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert (
+        returned["CLIENT_DEST_FOLDER_PATH"]
+        == "/Client Downloads/Pricing Tools/Customer Bids"
+    )
+    assert "DEST_FOLDER_PATH" not in returned
     assert not any("ENABLE_POSTPROCESS" in msg for msg in logs)
 
 

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -175,7 +175,6 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
             "p": 1,
             "CLIENT_DEST_SITE": "https://tenant.sharepoint.com/sites/demo",
             "CLIENT_DEST_FOLDER_PATH": "/docs/folder",
-            "DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
         }
         return ["ok"], payload
 


### PR DESCRIPTION
## Summary
- update PIT BID postprocess to populate CLIENT_DEST_FOLDER_PATH
- expect CLIENT_DEST_FOLDER_PATH and disallow DEST_FOLDER_PATH in PIT BID tests
- remove obsolete DEST_FOLDER_PATH from wizard postprocess test stub

## Testing
- `pytest tests/test_postprocess_runner.py`
- `pre-commit run --files app_utils/postprocess_runner.py tests/test_postprocess_runner.py tests/test_wizard_postprocess.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e2be948f08333b84ab4438aa406a1