### PR TITLE
refactor: update dest folder handling

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -75,13 +75,16 @@ def run_postprocess_if_configured(
         except RuntimeError as err:  # pragma: no cover - exercised in integration
             logs.append(f"Payload error: {err}")
             raise
-        payload["DEST_FOLDER_PATH"] = "/Client Downloads/Pricing Tools/Customer Bids"
+        dest_path: str = "/Client Downloads/Pricing Tools/Customer Bids"
+        payload["CLIENT_DEST_FOLDER_PATH"] = dest_path
         logs.append("Payload loaded")
         fname = f"{operation_cd} - BID - {customer_name}.xlsm"
         payload.setdefault("item/In_dtInputData", [{}])
         if not payload["item/In_dtInputData"]:
             payload["item/In_dtInputData"].append({})
         payload["item/In_dtInputData"][0]["NEW_EXCEL_FILENAME"] = fname
+        for entry in payload.get("item/In_dtInputData", []):
+            entry["CLIENT_DEST_FOLDER_PATH"] = dest_path
         if "BID-Payload" in payload:
             payload["BID-Payload"] = process_guid
         else:

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -120,7 +120,11 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     expected = 'OP - BID - Cust.xlsm'
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == "guid"
-    assert returned['DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert returned['CLIENT_DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert all(
+        item.get('CLIENT_DEST_FOLDER_PATH') == "/Client Downloads/Pricing Tools/Customer Bids"
+        for item in returned.get('item/In_dtInputData', [])
+    )
     assert called['url'] == tpl.postprocess.url
     assert called['json'] == returned
     assert "Payload loaded" in logs
@@ -168,7 +172,11 @@ def test_pit_bid_posts(monkeypatch):
     assert called['url'] == tpl.postprocess.url
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == 'guid'
-    assert returned['DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert returned['CLIENT_DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert all(
+        item.get('CLIENT_DEST_FOLDER_PATH') == "/Client Downloads/Pricing Tools/Customer Bids"
+        for item in returned.get('item/In_dtInputData', [])
+    )
     assert not any("ENABLE_POSTPROCESS" in msg for msg in logs)
 
 

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -175,7 +175,6 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
             "p": 1,
             "CLIENT_DEST_SITE": "https://tenant.sharepoint.com/sites/demo",
             "CLIENT_DEST_FOLDER_PATH": "/docs/folder",
-            "DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
         }
         return ["ok"], payload
 


### PR DESCRIPTION
## Summary
- replace DEST_FOLDER_PATH with CLIENT_DEST_FOLDER_PATH variable
- propagate client destination folder path to payload entries
- adjust tests for new dest path field

## Testing
- `pre-commit run --files app_utils/postprocess_runner.py tests/test_postprocess_runner.py tests/test_wizard_postprocess.py` *(fails: command not found)*
- `pytest tests/test_postprocess_runner.py tests/test_wizard_postprocess.py tests/test_cli.py tests/test_adhoc_labels.py`


------
https://chatgpt.com/codex/tasks/task_b_689e2bd635c883339c90006d53770ad3