### PR TITLE
Display SharePoint link from PIT payload

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -75,7 +75,7 @@ def run_postprocess_if_configured(
         except RuntimeError as err:  # pragma: no cover - exercised in integration
             logs.append(f"Payload error: {err}")
             raise
-        dest_path: str = "/Client  Downloads/Pricing Tools/Customer Bids"
+        dest_path: str = "/Client Downloads/Pricing Tools/Customer Bids"
         payload["CLIENT_DEST_FOLDER_PATH"] = dest_path
         logs.append("Payload loaded")
         fname = f"{operation_cd} - BID - {customer_name}.xlsm"

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -116,6 +116,17 @@ def run_app_with_labels(monkeypatch: MonkeyPatch) -> Tuple[Dict[str, object], Di
         "app_utils.azure_sql.fetch_operation_codes", lambda email=None: ["ADSJ_VAN"]
     )
     monkeypatch.setattr("app_utils.azure_sql.fetch_customers", lambda scac: [])
+    monkeypatch.setattr(
+        "app_utils.azure_sql.get_pit_url_payload",
+        lambda op_cd: {
+            "item/In_dtInputData": [
+                {
+                    "CLIENT_DEST_SITE": "https://tenant.sharepoint.com/sites/demo",
+                    "CLIENT_DEST_FOLDER_PATH": "/docs/folder",
+                }
+            ]
+        },
+    )
 
     captured: dict[str, object] = {}
 

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -174,9 +174,10 @@ def test_pit_bid_posts(monkeypatch):
     assert called['url'] == tpl.postprocess.url
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == 'guid'
-    assert returned['CLIENT_DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools"
+    expected_path = "/Client Downloads/Pricing Tools/Customer Bids"
+    assert returned['CLIENT_DEST_FOLDER_PATH'] == expected_path
     assert all(
-        item.get('CLIENT_DEST_FOLDER_PATH') == "/Client Downloads/Pricing Tools"
+        item.get('CLIENT_DEST_FOLDER_PATH') == expected_path
         for item in returned.get('item/In_dtInputData', [])
     )
     assert not any("ENABLE_POSTPROCESS" in msg for msg in logs)

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -155,6 +155,17 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
         ],
     )
     monkeypatch.setattr(
+        "app_utils.azure_sql.get_pit_url_payload",
+        lambda op_cd: {
+            "item/In_dtInputData": [
+                {
+                    "CLIENT_DEST_SITE": "https://tenant.sharepoint.com/sites/demo",
+                    "CLIENT_DEST_FOLDER_PATH": "/docs/folder",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
         "app_utils.azure_sql.insert_pit_bid_rows",
         lambda df, op, cust, ids, guid, adhoc: len(df),
     )


### PR DESCRIPTION
## Summary
- Read PIT payload to render SharePoint destination link before export
- Fallback to nested payload values after post-process completion
- Normalize BID export destination path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e695b91fc8333bfa8e53f51375e8a