### PR TITLE
Disable postprocess button after initial click

### DIFF
--- a/app.py
+++ b/app.py
@@ -506,6 +506,7 @@ def main():
                 "export_complete",
                 "mapped_csv",
                 "mapped_preview_df",
+                "postprocess_run_clicked",
             ]:
                 st.session_state.pop(key, None)
             st.session_state.pop(f"layer_confirmed_{last_idx}", None)
@@ -559,7 +560,13 @@ def main():
                 unsafe_allow_html=True,
             )
 
-            if st.button(button_text, key="postprocess_run", type="primary"):
+            if st.button(
+                button_text,
+                key="postprocess_run",
+                type="primary",
+                disabled=st.session_state.get("postprocess_run_clicked", False),
+            ):
+                st.session_state["postprocess_run_clicked"] = True
                 with st.spinner("Gathering mileage and toll data…"):
                     st.markdown(
                         ":blue[This process can take up to 10 minutes...]"

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -77,7 +77,7 @@ def run_postprocess_if_configured(
         except RuntimeError as err:  # pragma: no cover - exercised in integration
             logs.append(f"Payload error: {err}")
             raise
-        dest_path: str = "/CLIENT  Downloads/Pricing Tools/Customer Bids"
+        dest_path: str = "/Client Downloads/Pricing Tools/Customer Bids"
         payload["CLIENT_DEST_FOLDER_PATH"] = dest_path
         logs.append("Payload loaded")
 

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -2,6 +2,7 @@ import types
 import sys
 import logging
 from typing import Any, Dict
+from datetime import datetime
 import pandas as pd
 import pytest
 from schemas.template_v2 import PostprocessSpec, Template
@@ -100,6 +101,10 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
         'app_utils.postprocess_runner.wait_for_postprocess_completion',
         lambda *a, **k: None,
     )
+    monkeypatch.setattr(
+        'app_utils.postprocess_runner.datetime',
+        types.SimpleNamespace(now=lambda: datetime(2020, 1, 1)),
+    )
     called = {}
 
     def fake_post(url, json=None, timeout=10):  # pragma: no cover - executed via call
@@ -119,7 +124,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
         operation_cd='OP',
         customer_name='Cust',
     )
-    expected = 'OP - BID - Cust.xlsm'
+    expected = 'OP - BID - Cust_20200101.xlsm'
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == "guid"
     assert returned['CLIENT_DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
@@ -149,6 +154,10 @@ def test_pit_bid_posts(monkeypatch):
         'app_utils.postprocess_runner.wait_for_postprocess_completion',
         lambda *a, **k: None,
     )
+    monkeypatch.setattr(
+        'app_utils.postprocess_runner.datetime',
+        types.SimpleNamespace(now=lambda: datetime(2020, 1, 1)),
+    )
     called: dict[str, Any] = {}
 
     def fake_post(url, json=None, timeout=10):  # pragma: no cover - executed via call
@@ -170,7 +179,7 @@ def test_pit_bid_posts(monkeypatch):
     )
     assert "Payload loaded" in logs
     assert "Payload finalized" in logs
-    expected = 'OP - BID - Cust.xlsm'
+    expected = 'OP - BID - Cust_20200101.xlsm'
     assert logs[-1] == 'Done'
     assert called['url'] == tpl.postprocess.url
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -88,6 +88,8 @@ class DummyStreamlit:
             if self.run_idx < len(self.button_sequence)
             else set()
         )
+        if k.get("disabled"):
+            return False
         return label in presses
     def spinner(self, msg, *a, **k):
         class _C(DummyContainer):
@@ -260,10 +262,22 @@ def test_back_after_export(monkeypatch):
     for key in ["export_complete", "mapped_csv"]:
         assert key not in state
     assert "layer_confirmed_0" not in state
+    assert "postprocess_run_clicked" not in state
 
 
 def test_dataframe_previews(monkeypatch):
     _, state, st = run_app(monkeypatch)
     assert state.get("export_complete")
     assert len(st.dataframe_calls) >= 2
+
+
+def test_postprocess_flag_set(monkeypatch):
+    _, state, _ = run_app(monkeypatch)
+    assert state.get("postprocess_run_clicked") is True
+
+
+def test_postprocess_button_disabled_on_second_click(monkeypatch):
+    _, state, st = run_app(monkeypatch, button_sequence=[{"Generate BID"}, {"Generate BID"}])
+    assert state.get("postprocess_run_clicked") is True
+    assert st.spinner_messages.count("Gathering mileage and toll data…") == 1
 


### PR DESCRIPTION
## Summary
- Prevent repeated postprocess runs by tracking click state and disabling the run button
- Reset postprocess button state when navigating back to mappings
- Fix postprocess payload destination path and add tests for postprocess timing and button state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f517c67248333b8596628e5455cdf