### PR TITLE
docs: document SharePoint upload path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ python start_postprocess.py
 ```
 
 See `docs/template_spec.md` for details.
+
+## SharePoint uploads
+
+All SharePoint exports must be uploaded to:
+
+```
+/CLIENT  Downloads/Pricing Tools/Customer Bids
+```
+
+This path is case-sensitive and includes two spaces between `CLIENT` and `Downloads`. Keep the exact spacing and capitalization to avoid broken links or misplaced files.

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -90,7 +90,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     payload = {
         "item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}],
         "BID-Payload": "",
-        "CLIENT_DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
+        "CLIENT_DEST_FOLDER_PATH": "/CLIENT  Downloads/Pricing Tools/Customer Bids",
     }
 
     monkeypatch.setattr(
@@ -127,9 +127,9 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     expected = 'OP - BID - Cust_20200101.xlsm'
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == "guid"
-    assert returned['CLIENT_DEST_FOLDER_PATH'] == "/Client Downloads/Pricing Tools/Customer Bids"
+    assert returned['CLIENT_DEST_FOLDER_PATH'] == "/CLIENT  Downloads/Pricing Tools/Customer Bids"
     assert all(
-        item.get('CLIENT_DEST_FOLDER_PATH') == "/Client Downloads/Pricing Tools/Customer Bids"
+        item.get('CLIENT_DEST_FOLDER_PATH') == "/CLIENT  Downloads/Pricing Tools/Customer Bids"
         for item in returned.get('item/In_dtInputData', [])
     )
     assert called['url'] == tpl.postprocess.url
@@ -144,7 +144,7 @@ def test_pit_bid_posts(monkeypatch):
     payload = {
         "item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}],
         "BID-Payload": "",
-        "CLIENT_DEST_FOLDER_PATH": "/Client Downloads/Pricing Tools/Customer Bids",
+        "CLIENT_DEST_FOLDER_PATH": "/CLIENT  Downloads/Pricing Tools/Customer Bids",
     }
     monkeypatch.setattr(
         'app_utils.postprocess_runner.get_pit_url_payload',
@@ -184,7 +184,7 @@ def test_pit_bid_posts(monkeypatch):
     assert called['url'] == tpl.postprocess.url
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == 'guid'
-    expected_path = "/Client Downloads/Pricing Tools/Customer Bids"
+    expected_path = "/CLIENT  Downloads/Pricing Tools/Customer Bids"
     assert returned['CLIENT_DEST_FOLDER_PATH'] == expected_path
     assert all(
         item.get('CLIENT_DEST_FOLDER_PATH') == expected_path


### PR DESCRIPTION
## Summary
- note case-sensitive SharePoint upload path `/CLIENT  Downloads/Pricing Tools/Customer Bids`
- warn developers to preserve spacing and capitalization
- align postprocess tests with new path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f5b5053188333a29959ef3caaf6ec