### PR TITLE
refactor: centralize client bids dest path constant

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -10,6 +10,8 @@ from schemas.template_v2 import PostprocessSpec, Template
 from app_utils.dataframe_transform import apply_header_mappings
 from app_utils.azure_sql import get_pit_url_payload, wait_for_postprocess_completion
 
+CLIENT_BIDS_DEST_PATH: str = "/CLIENT  Downloads/Pricing Tools/Customer Bids"
+
 
 def run_postprocess(
     cfg: PostprocessSpec, df: pd.DataFrame, log: List[str] | None = None
@@ -77,8 +79,7 @@ def run_postprocess_if_configured(
         except RuntimeError as err:  # pragma: no cover - exercised in integration
             logs.append(f"Payload error: {err}")
             raise
-        dest_path: str = "/CLIENT  Downloads/Pricing Tools/Customer Bids"
-        payload["CLIENT_DEST_FOLDER_PATH"] = dest_path
+        payload["CLIENT_DEST_FOLDER_PATH"] = CLIENT_BIDS_DEST_PATH
         logs.append("Payload loaded")
 
         # Generate filename with current date
@@ -90,7 +91,7 @@ def run_postprocess_if_configured(
             payload["item/In_dtInputData"].append({})
         payload["item/In_dtInputData"][0]["NEW_EXCEL_FILENAME"] = fname
         for entry in payload.get("item/In_dtInputData", []):
-            entry["CLIENT_DEST_FOLDER_PATH"] = dest_path
+            entry["CLIENT_DEST_FOLDER_PATH"] = CLIENT_BIDS_DEST_PATH
         if "BID-Payload" in payload:
             payload["BID-Payload"] = process_guid
         else:

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -6,7 +6,11 @@ from datetime import datetime
 import pandas as pd
 import pytest
 from schemas.template_v2 import PostprocessSpec, Template
-from app_utils.postprocess_runner import run_postprocess, run_postprocess_if_configured
+from app_utils.postprocess_runner import (
+    CLIENT_BIDS_DEST_PATH,
+    run_postprocess,
+    run_postprocess_if_configured,
+)
 
 
 def test_run_postprocess_calls_requests(load_env, monkeypatch):
@@ -90,7 +94,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     payload = {
         "item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}],
         "BID-Payload": "",
-        "CLIENT_DEST_FOLDER_PATH": "/CLIENT  Downloads/Pricing Tools/Customer Bids",
+        "CLIENT_DEST_FOLDER_PATH": CLIENT_BIDS_DEST_PATH,
     }
 
     monkeypatch.setattr(
@@ -127,9 +131,9 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     expected = 'OP - BID - Cust_20200101.xlsm'
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == "guid"
-    assert returned['CLIENT_DEST_FOLDER_PATH'] == "/CLIENT  Downloads/Pricing Tools/Customer Bids"
+    assert returned['CLIENT_DEST_FOLDER_PATH'] == CLIENT_BIDS_DEST_PATH
     assert all(
-        item.get('CLIENT_DEST_FOLDER_PATH') == "/CLIENT  Downloads/Pricing Tools/Customer Bids"
+        item.get('CLIENT_DEST_FOLDER_PATH') == CLIENT_BIDS_DEST_PATH
         for item in returned.get('item/In_dtInputData', [])
     )
     assert called['url'] == tpl.postprocess.url
@@ -144,7 +148,7 @@ def test_pit_bid_posts(monkeypatch):
     payload = {
         "item/In_dtInputData": [{"NEW_EXCEL_FILENAME": "old.xlsm"}],
         "BID-Payload": "",
-        "CLIENT_DEST_FOLDER_PATH": "/CLIENT  Downloads/Pricing Tools/Customer Bids",
+        "CLIENT_DEST_FOLDER_PATH": CLIENT_BIDS_DEST_PATH,
     }
     monkeypatch.setattr(
         'app_utils.postprocess_runner.get_pit_url_payload',
@@ -184,7 +188,7 @@ def test_pit_bid_posts(monkeypatch):
     assert called['url'] == tpl.postprocess.url
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
     assert returned['BID-Payload'] == 'guid'
-    expected_path = "/CLIENT  Downloads/Pricing Tools/Customer Bids"
+    expected_path = CLIENT_BIDS_DEST_PATH
     assert returned['CLIENT_DEST_FOLDER_PATH'] == expected_path
     assert all(
         item.get('CLIENT_DEST_FOLDER_PATH') == expected_path


### PR DESCRIPTION
## Summary
- add `CLIENT_BIDS_DEST_PATH` constant for PIT BID postprocessing
- replace hard-coded client destination path usage in runner and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f644cc3a083339e673d30ab57f8a7