### PR TITLE
Rename Breakthrough Fuel bid field

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -28,7 +28,7 @@ PIT_BID_FIELD_MAP: Dict[str, str] = {
     "Customer Name": "CUSTOMER_NAME",
     "Freight Type": "FREIGHT_TYPE",
     "Temp Cat": "TEMP_CAT",
-    "BTF FSC Per Mile": "BTF_FSC_PER_MILE",
+    "Breakthrough Fuel": "BTF_FSC_PER_MILE",
     "Volume Frequency": "VOLUME_FREQUENCY",
 }
 

--- a/tests/test_azure_sql.py
+++ b/tests/test_azure_sql.py
@@ -29,7 +29,7 @@ def test_pit_bid_field_map_alignment():
         "Customer Name": "CUSTOMER_NAME",
         "Freight Type": "FREIGHT_TYPE",
         "Temp Cat": "TEMP_CAT",
-        "BTF FSC Per Mile": "BTF_FSC_PER_MILE",
+        "Breakthrough Fuel": "BTF_FSC_PER_MILE",
         "Volume Frequency": "VOLUME_FREQUENCY",
     }
     assert azure_sql.PIT_BID_FIELD_MAP == expected


### PR DESCRIPTION
## Summary
- Use "Breakthrough Fuel" as the PIT bid field key for `BTF_FSC_PER_MILE`
- Update unit test expectations for revised field name

## Testing
- `export AAD_CLIENT_ID=dummy AAD_TENANT_ID=dummy AAD_REDIRECT_URI=dummy DISABLE_AUTH=1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f6dd63e8083338eea1ec6148ce626