### PR TITLE
Fix header mapping suggestions clearing optional fields

### DIFF
--- a/app_utils/suggestion_store.py
+++ b/app_utils/suggestion_store.py
@@ -5,7 +5,9 @@ import re
 import hashlib
 from typing import List, Optional, TypedDict
 
-SUGGESTION_FILE = Path("data/mapping_suggestions.json")
+SUGGESTION_FILE = (
+    Path(__file__).resolve().parent.parent / "data" / "mapping_suggestions.json"
+)
 
 
 class Suggestion(TypedDict, total=False):

--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -117,9 +117,9 @@ def render(layer, idx: int) -> None:
     if not st.session_state.get(ai_flag):
         before = mapping.copy()
         with st.spinner("Querying GPT..."):
-            mapping = apply_gpt_header_fallback(mapping, source_cols, targets=required_keys)
-        for k in optional_keys + adhoc_keys:
-            mapping[k] = {}
+            mapping = apply_gpt_header_fallback(
+                mapping, source_cols, targets=required_keys
+            )
         st.session_state[map_key] = mapping
         st.session_state[ai_flag] = True
         if mapping != before:


### PR DESCRIPTION
## Summary
- ensure GPT fallback does not clear existing optional header mappings
- load mapping suggestions from package-relative path
- test that exact matches and saved suggestions prepopulate header mappings

## Testing
- `pytest tests/test_suggestion_store.py tests/test_header_mapping.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f734423e483338bc6fca1d6b0c72e