### PR TITLE
Capture operation code when logging mapping process

### DIFF
--- a/app.py
+++ b/app.py
@@ -626,6 +626,7 @@ def main():
                         selected_file,
                         json.dumps(final_json),
                         template_obj.template_guid,
+                        st.session_state.get("operation_code"),
                         adhoc_headers,
                     )
                     _, payload = run_postprocess_if_configured(

--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -680,6 +680,7 @@ def log_mapping_process(
     file_name_string: str,
     process_json: dict | str,
     template_guid: str,
+    operation_cd: str | None,
     adhoc_headers: Dict[str, str] | None = None,
 ) -> None:
     """Insert a record into ``dbo.MAPPING_AGENT_PROCESSES``."""
@@ -690,7 +691,7 @@ def log_mapping_process(
         payload["adhoc_headers"] = adhoc_headers
     with _connect() as conn:
         conn.cursor().execute(
-            "INSERT INTO dbo.MAPPING_AGENT_PROCESSES (PROCESS_GUID, TEMPLATE_NAME, FRIENDLY_NAME, CREATED_BY, CREATED_DTTM, FILE_NAME_STRING, PROCESS_JSON, TEMPLATE_GUID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO dbo.MAPPING_AGENT_PROCESSES (PROCESS_GUID, TEMPLATE_NAME, FRIENDLY_NAME, CREATED_BY, CREATED_DTTM, FILE_NAME_STRING, PROCESS_JSON, TEMPLATE_GUID, OPERATION_CD) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 process_guid,
                 template_name,
@@ -700,5 +701,6 @@ def log_mapping_process(
                 file_name_string,
                 json.dumps(payload),
                 template_guid,
+                operation_cd,
             ),
         )

--- a/cli.py
+++ b/cli.py
@@ -141,6 +141,7 @@ def main() -> None:
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
+                args.operation_code,
                 adhoc_headers,
             )
             logs_post, payload = run_postprocess_if_configured(
@@ -163,6 +164,7 @@ def main() -> None:
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
+                args.operation_code,
                 adhoc_headers,
             )
     else:
@@ -174,6 +176,7 @@ def main() -> None:
             args.template.name,
             json.dumps(mapped),
             template.template_guid,
+            args.operation_code,
             None,
         )
 

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -146,6 +146,7 @@ def run_app_with_labels(monkeypatch: MonkeyPatch) -> Tuple[Dict[str, object], Di
         file_name_string,
         process_json,
         template_guid,
+        operation_cd,
         adhoc_headers=None,
     ):
         captured["log_adhoc"] = adhoc_headers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ def test_cli_basic(monkeypatch, tmp_path: Path):
     out = tmp_path / 'out.json'
     captured: dict[str, object] = {}
 
-    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, adhoc_headers=None):
+    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, operation_cd, adhoc_headers=None):
         captured.update(
             {
                 'process_guid': process_guid,
@@ -25,6 +25,7 @@ def test_cli_basic(monkeypatch, tmp_path: Path):
                 'file_name_string': file_name_string,
                 'process_json': process_json,
                 'template_guid': template_guid,
+                'operation_cd': operation_cd,
                 'adhoc_headers': adhoc_headers,
             }
         )
@@ -45,6 +46,7 @@ def test_cli_basic(monkeypatch, tmp_path: Path):
     assert captured['friendly_name'] == 'simple-template'
     assert captured['user_email'] == 'user@example.com'
     assert captured['file_name_string'] == tpl.name
+    assert captured['operation_cd'] is None
 
 
 def test_cli_csv_output(monkeypatch, tmp_path: Path):

--- a/tests/test_log_mapping_process.py
+++ b/tests/test_log_mapping_process.py
@@ -38,9 +38,11 @@ def test_log_mapping_process(monkeypatch, payload):
         "file.csv",
         payload,
         "tmpl-guid",
+        "OP",
         adhoc,
     )
     assert "MAPPING_AGENT_PROCESSES" in captured["query"]
+    assert "OPERATION_CD" in captured["query"]
     params = captured["params"]
     assert params[0] == "proc"
     assert params[1] == "template-name"
@@ -53,3 +55,4 @@ def test_log_mapping_process(monkeypatch, payload):
     expected["adhoc_headers"] = adhoc
     assert stored == expected
     assert params[7] == "tmpl-guid"
+    assert params[8] == "OP"

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -176,7 +176,17 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
         lambda df, op, cust, ids, guid, adhoc: len(df),
     )
     monkeypatch.setattr("app_utils.azure_sql.derive_adhoc_headers", lambda df: {})
-    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, adhoc_headers=None):
+    def fake_log(
+        process_guid,
+        template_name,
+        friendly_name,
+        user_email,
+        file_name_string,
+        process_json,
+        template_guid,
+        operation_cd,
+        adhoc_headers=None,
+    ):
         called["log_guid"] = process_guid
         called["log_template"] = template_name
         called["log_friendly"] = friendly_name


### PR DESCRIPTION
## Summary
- log operation code via new OPERATION_CD column in `log_mapping_process`
- pass operation code from CLI arguments and Streamlit session to SQL logger
- test logging includes operation code

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f7a677f4c83338e0fe77253091bc9