### PR TITLE
refactor: move operation code arg

### DIFF
--- a/app.py
+++ b/app.py
@@ -622,13 +622,13 @@ def main():
                     )
                     azure_sql.log_mapping_process(
                         guid,
+                        st.session_state.get("operation_code"),
                         slugify(template_obj.template_name),
                         template_obj.template_name,
                         auth.get_user_email(),
                         selected_file,
                         json.dumps(final_json),
                         template_obj.template_guid,
-                        st.session_state.get("operation_code"),
                         adhoc_headers,
                     )
                     _, payload = run_postprocess_if_configured(

--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -683,7 +683,10 @@ def log_mapping_process(
     template_guid: str,
     adhoc_headers: Dict[str, str] | None = None,
 ) -> None:
-    """Insert a record into ``dbo.MAPPING_AGENT_PROCESSES``."""
+    """Insert a record into ``dbo.MAPPING_AGENT_PROCESSES``.
+
+    ``operation_cd`` is optional and may be ``None``.
+    """
     payload = (
         json.loads(process_json) if isinstance(process_json, str) else dict(process_json)
     )

--- a/cli.py
+++ b/cli.py
@@ -135,13 +135,13 @@ def main() -> None:
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
             azure_sql.log_mapping_process(
                 process_guid,
+                args.operation_code,
                 args.template.stem,
                 template.template_name,
                 args.user_email,
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
-                args.operation_code,
                 adhoc_headers,
             )
             logs_post, payload = run_postprocess_if_configured(
@@ -158,25 +158,25 @@ def main() -> None:
         else:
             azure_sql.log_mapping_process(
                 process_guid,
+                args.operation_code,
                 args.template.stem,
                 template.template_name,
                 args.user_email,
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
-                args.operation_code,
                 adhoc_headers,
             )
     else:
         azure_sql.log_mapping_process(
             process_guid,
+            args.operation_code,
             args.template.stem,
             template.template_name,
             args.user_email,
             args.template.name,
             json.dumps(mapped),
             template.template_guid,
-            args.operation_code,
             None,
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,18 +14,27 @@ def test_cli_basic(monkeypatch, tmp_path: Path):
     src = Path('tests/fixtures/simple.csv')
     out = tmp_path / 'out.json'
     captured: dict[str, object] = {}
-
-    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, operation_cd, adhoc_headers=None):
+    def fake_log(
+        process_guid,
+        operation_cd,
+        template_name,
+        friendly_name,
+        user_email,
+        file_name_string,
+        process_json,
+        template_guid,
+        adhoc_headers=None,
+    ):
         captured.update(
             {
                 'process_guid': process_guid,
+                'operation_cd': operation_cd,
                 'template_name': template_name,
                 'friendly_name': friendly_name,
                 'user_email': user_email,
                 'file_name_string': file_name_string,
                 'process_json': process_json,
                 'template_guid': template_guid,
-                'operation_cd': operation_cd,
                 'adhoc_headers': adhoc_headers,
             }
         )

--- a/tests/test_log_mapping_process.py
+++ b/tests/test_log_mapping_process.py
@@ -32,27 +32,27 @@ def test_log_mapping_process(monkeypatch, payload):
     adhoc = {"ADHOC_INFO1": "Foo"}
     azure_sql.log_mapping_process(
         "proc",
+        "OP",
         "template-name",
         "Friendly",
         "user@example.com",
         "file.csv",
         payload,
         "tmpl-guid",
-        "OP",
         adhoc,
     )
     assert "MAPPING_AGENT_PROCESSES" in captured["query"]
     assert "OPERATION_CD" in captured["query"]
     params = captured["params"]
     assert params[0] == "proc"
-    assert params[1] == "template-name"
-    assert params[2] == "Friendly"
-    assert params[3] == "user@example.com"
-    assert isinstance(params[4], datetime)
-    assert params[5] == "file.csv"
-    stored = json.loads(params[6])
+    assert params[1] == "OP"
+    assert params[2] == "template-name"
+    assert params[3] == "Friendly"
+    assert params[4] == "user@example.com"
+    assert isinstance(params[5], datetime)
+    assert params[6] == "file.csv"
+    stored = json.loads(params[7])
     expected = json.loads(payload) if isinstance(payload, str) else payload
     expected["adhoc_headers"] = adhoc
     assert stored == expected
-    assert params[7] == "tmpl-guid"
-    assert params[8] == "OP"
+    assert params[8] == "tmpl-guid"

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -178,13 +178,13 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     monkeypatch.setattr("app_utils.azure_sql.derive_adhoc_headers", lambda df: {})
     def fake_log(
         process_guid,
+        operation_cd,
         template_name,
         friendly_name,
         user_email,
         file_name_string,
         process_json,
         template_guid,
-        operation_cd,
         adhoc_headers=None,
     ):
         called["log_guid"] = process_guid


### PR DESCRIPTION
## Summary
- move `operation_cd` to second parameter in `log_mapping_process`
- update call sites and tests for new `log_mapping_process` signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f7e604a4c8333bf18f0342e7648fb