### PR TITLE
Order operation code second for log_mapping_process

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,11 +24,14 @@ from urllib.parse import quote
 import streamlit as st
 from pydantic import ValidationError
 import auth
+
 try:
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover - optional dependency
+
     def load_dotenv() -> None:
         return None
+
 
 from auth import require_login, logout_button, get_user_email
 from app_utils.user_prefs import get_last_template, set_last_template
@@ -120,9 +123,7 @@ def main():
         st.warning(
             "Unsaved template changes detected. Save before leaving to keep your work."
         )
-        st.caption(
-            "Template edits exist only in this session until you save them."
-        )
+        st.caption("Template edits exist only in this session until you save them.")
         save_col, mgr_col = st.columns(2)
         save_col.button("Save Template", on_click=save_current_template)
         mgr_col.page_link(
@@ -278,9 +279,8 @@ def main():
                 )
             if sheet_key not in st.session_state and sheets:
                 st.session_state[sheet_key] = sheets[default_idx]
-            if (
-                st.session_state.get("upload_sheet")
-                and hasattr(st.session_state["uploaded_file"], "name")
+            if st.session_state.get("upload_sheet") and hasattr(
+                st.session_state["uploaded_file"], "name"
             ):
                 df, _ = read_tabular_file(
                     st.session_state["uploaded_file"],
@@ -291,7 +291,7 @@ def main():
 
     customer_valid = True
     st.session_state.setdefault("customer_ids", None)
-    
+
     if hasattr(st, "divider"):
         if hasattr(st, "divider"):
             st.divider()
@@ -318,8 +318,7 @@ def main():
                     st.session_state["customer_scac"] = scac
                     if (
                         st.session_state["customer_options"]
-                        and "CLIENT_SCAC"
-                        in st.session_state["customer_options"][0]
+                        and "CLIENT_SCAC" in st.session_state["customer_options"][0]
                     ):
                         st.session_state["client_scac"] = st.session_state[
                             "customer_options"
@@ -348,7 +347,9 @@ def main():
                 ):
                     prev_choice = st.session_state["customer_name"]
                     st.session_state["customer_choice"] = prev_choice
-                idx = cust_names.index(prev_choice) if prev_choice in cust_names else None
+                idx = (
+                    cust_names.index(prev_choice) if prev_choice in cust_names else None
+                )
                 try:
                     cust_col, _ = st.columns([3, 1])
                 except TypeError:
@@ -362,7 +363,9 @@ def main():
                     placeholder="Select a customer",
                 )
                 if selected_name == "+ New Customer":
-                    new_name: str = st.text_input("Customer Name", key="new_customer_name")
+                    new_name: str = st.text_input(
+                        "Customer Name", key="new_customer_name"
+                    )
                     customer_name = new_name.strip().title() if new_name else ""
                     st.session_state["customer_name"] = customer_name
                     st.session_state["customer_id_options"] = []
@@ -392,9 +395,12 @@ def main():
                         ]
                         st.session_state["customer_id_options"] = billto_ids
                         if billto_ids:
-                            if len(billto_ids) == 1 and not st.session_state.get("customer_ids"):
+                            if len(billto_ids) == 1 and not st.session_state.get(
+                                "customer_ids"
+                            ):
                                 st.session_state["customer_ids"] = billto_ids[:1]
                             else:
+
                                 def select_all_ids() -> None:
                                     st.session_state["customer_ids"] = billto_ids[:5]
 
@@ -405,7 +411,9 @@ def main():
                                 # st.markdown("**Customer ID**")
 
                                 try:
-                                    cid_col, actions_col = st.columns([3, 1], gap="small")
+                                    cid_col, actions_col = st.columns(
+                                        [3, 1], gap="small"
+                                    )
                                 except TypeError:
                                     try:
                                         cid_col, actions_col = st.columns([3, 1])
@@ -413,24 +421,37 @@ def main():
                                         cid_col, actions_col = st.columns(2)
 
                                 # The input itself (label collapsed so tops align)
-                                multiselect_fn = getattr(cid_col, "multiselect", st.multiselect)
+                                multiselect_fn = getattr(
+                                    cid_col, "multiselect", st.multiselect
+                                )
                                 multiselect_fn(
                                     "Customer ID",
                                     billto_ids,
                                     key="customer_ids",
                                     max_selections=5,
                                     label_visibility="collapsed",
-                                    placeholder="Select Customer ID"
+                                    placeholder="Select Customer ID",
                                 )
 
                                 # Buttons column, vertically centered to the input row
                                 with actions_col:
                                     anchor_id = f"cid_actions_{uuid.uuid4().hex[:6]}"
-                                    st.markdown(f"<span id='{anchor_id}'></span>", unsafe_allow_html=True)
+                                    st.markdown(
+                                        f"<span id='{anchor_id}'></span>",
+                                        unsafe_allow_html=True,
+                                    )
 
                                     b1, b2 = st.columns(2, gap="small")
-                                    b1.button("Select all", on_click=select_all_ids, key="cid_select_all")
-                                    b2.button("Deselect all", on_click=deselect_all_ids, key="cid_clear_all")
+                                    b1.button(
+                                        "Select all",
+                                        on_click=select_all_ids,
+                                        key="cid_select_all",
+                                    )
+                                    b2.button(
+                                        "Deselect all",
+                                        on_click=deselect_all_ids,
+                                        key="cid_clear_all",
+                                    )
 
                                     st.markdown(
                                         f"""
@@ -518,12 +539,12 @@ def main():
             st.session_state.pop(f"layer_confirmed_{last_idx}", None)
             st.session_state["current_step"] = compute_current_step()
             st.rerun()
-        
+
         if hasattr(st, "divider"):
             st.divider()
         else:  # pragma: no cover - Streamlit <1.20 or test stubs
             st.markdown("---")
-        
+
         if not st.session_state.get("export_complete"):
             header_text: str = "Step — Run Export"
             button_text: str = "Run Export"
@@ -531,7 +552,6 @@ def main():
                 header_text = "Step 2 - Generate BID File"
                 button_text = "Generate BID"
             st.header(header_text)
-
 
             sheet = st.session_state.get("upload_sheet", 0)
             df, _ = read_tabular_file(
@@ -574,23 +594,19 @@ def main():
             ):
                 st.session_state["postprocess_run_clicked"] = True
                 with st.spinner("Gathering mileage and toll data…"):
-                    st.markdown(
-                        ":blue[This process can take up to 10 minutes...]"
+                    st.markdown(":blue[This process can take up to 10 minutes...]")
+                    preview_payload: dict[str, Any] = azure_sql.get_pit_url_payload(
+                        st.session_state["operation_code"]
                     )
-                    preview_payload: dict[str, Any] = (
-                        azure_sql.get_pit_url_payload(
-                            st.session_state["operation_code"]
-                        )
-                    )
-                    preview_item = (
-                        preview_payload.get("item/In_dtInputData") or [{}]
-                    )[0]
+                    preview_item = (preview_payload.get("item/In_dtInputData") or [{}])[
+                        0
+                    ]
                     dest_site: str | None = preview_item.get("CLIENT_DEST_SITE")
-                    dest_path: str | None = preview_item.get(
-                        "CLIENT_DEST_FOLDER_PATH"
-                    )
+                    dest_path: str | None = preview_item.get("CLIENT_DEST_FOLDER_PATH")
                     if dest_site and dest_path:
-                        sharepoint_url = f"{dest_site.rstrip('/')}{quote(dest_path, safe='/')}"
+                        sharepoint_url = (
+                            f"{dest_site.rstrip('/')}{quote(dest_path, safe='/')}"
+                        )
                         st.link_button("Open SharePoint folder", sharepoint_url)
                     sheet = st.session_state.get("upload_sheet", 0)
                     df, _ = read_tabular_file(
@@ -608,10 +624,9 @@ def main():
                         tmp_path = Path(tmp.name)
                         mapped_df = save_mapped_csv(df, final_json, tmp_path)
 
-                    adhoc_headers = (
-                        st.session_state.get("header_adhoc_headers")
-                        or azure_sql.derive_adhoc_headers(mapped_df)
-                    )
+                    adhoc_headers = st.session_state.get(
+                        "header_adhoc_headers"
+                    ) or azure_sql.derive_adhoc_headers(mapped_df)
                     insert_pit_bid_rows(
                         mapped_df,
                         st.session_state["operation_code"],
@@ -622,13 +637,13 @@ def main():
                     )
                     azure_sql.log_mapping_process(
                         guid,
+                        st.session_state.get("operation_code"),
                         slugify(template_obj.template_name),
                         template_obj.template_name,
                         auth.get_user_email(),
                         selected_file,
                         json.dumps(final_json),
                         template_obj.template_guid,
-                        st.session_state.get("operation_code"),
                         adhoc_headers,
                     )
                     _, payload = run_postprocess_if_configured(
@@ -654,9 +669,7 @@ def main():
             st.success(
                 "Your PIT is being created and will be uploaded to your SharePoint site in ~5 minutes."
             )
-            payload: dict[str, Any] = (
-                st.session_state.get("postprocess_payload") or {}
-            )
+            payload: dict[str, Any] = st.session_state.get("postprocess_payload") or {}
             dest_site: str | None = payload.get("CLIENT_DEST_SITE")
             dest_path: str | None = payload.get("CLIENT_DEST_FOLDER_PATH")
             if not (dest_site and dest_path):
@@ -684,10 +697,12 @@ def main():
             st.info("Please select a template to begin.")
         elif not st.session_state.get("uploaded_file"):
             st.info("Please upload a client data file to continue.")
-            
+
     st.markdown(
         "<div style='margin-bottom: 240px'></div>",
         unsafe_allow_html=True,
     )
+
+
 main()
 logout_button()

--- a/cli.py
+++ b/cli.py
@@ -5,11 +5,14 @@ from typing import Any, Dict
 import uuid
 
 import pandas as pd
+
 try:
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover - optional dependency
+
     def load_dotenv() -> None:
         return None
+
 
 load_dotenv()
 
@@ -52,7 +55,9 @@ def auto_map(template: Template, df: pd.DataFrame) -> Dict[str, Any]:
                 unique_vals = sorted(df[src].dropna().unique().astype(str))
                 records = getattr(template, layer.dictionary_sheet, [])
                 dict_vals = [rec[layer.target_field] for rec in records]
-                state[f"lookup_mapping_{idx}"] = match_lookup_values(dict_vals, unique_vals)
+                state[f"lookup_mapping_{idx}"] = match_lookup_values(
+                    dict_vals, unique_vals
+                )
         elif layer.type == "computed":
             result = resolve_computed_layer(layer.model_dump(), df)
             state[f"computed_result_{idx}"] = result
@@ -135,13 +140,13 @@ def main() -> None:
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
             azure_sql.log_mapping_process(
                 process_guid,
+                args.operation_code,
                 args.template.stem,
                 template.template_name,
                 args.user_email,
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
-                args.operation_code,
                 adhoc_headers,
             )
             logs_post, payload = run_postprocess_if_configured(
@@ -158,25 +163,25 @@ def main() -> None:
         else:
             azure_sql.log_mapping_process(
                 process_guid,
+                args.operation_code,
                 args.template.stem,
                 template.template_name,
                 args.user_email,
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
-                args.operation_code,
                 adhoc_headers,
             )
     else:
         azure_sql.log_mapping_process(
             process_guid,
+            args.operation_code,
             args.template.stem,
             template.template_name,
             args.user_email,
             args.template.name,
             json.dumps(mapped),
             template.template_guid,
-            args.operation_code,
             None,
         )
 

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -87,10 +87,14 @@ def setup_header_env(monkeypatch: MonkeyPatch) -> HeaderDummyStreamlit:
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setattr(header_step, "st", st)
     monkeypatch.setattr(
-        header_step, "read_tabular_file", lambda _f, sheet_name=None: (pd.DataFrame(), ["A", "B"])
+        header_step,
+        "read_tabular_file",
+        lambda _f, sheet_name=None: (pd.DataFrame(), ["A", "B"]),
     )
     monkeypatch.setattr(
-        header_step, "suggest_header_mapping", lambda fields, cols: {k: {} for k in fields}
+        header_step,
+        "suggest_header_mapping",
+        lambda fields, cols: {k: {} for k in fields},
     )
     monkeypatch.setattr(
         header_step, "apply_gpt_header_fallback", lambda m, c, targets=None: m
@@ -98,16 +102,21 @@ def setup_header_env(monkeypatch: MonkeyPatch) -> HeaderDummyStreamlit:
     monkeypatch.setattr(header_step, "get_suggestions", lambda *a, **k: [])
     monkeypatch.setattr(header_step, "add_suggestion", lambda *a, **k: None)
     import app_utils.ui.header_utils as header_utils
+
     monkeypatch.setattr(header_utils, "st", st)
     st.session_state.update({"uploaded_file": object(), "current_template": "demo"})
     return st
 
 
-def run_app_with_labels(monkeypatch: MonkeyPatch) -> Tuple[Dict[str, object], Dict[str, object]]:
+def run_app_with_labels(
+    monkeypatch: MonkeyPatch,
+) -> Tuple[Dict[str, object], Dict[str, object]]:
     st = DummyStreamlit([{"Generate BID"}])
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setenv("DISABLE_AUTH", "1")
-    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setitem(
+        sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None)
+    )
     monkeypatch.setattr("auth.logout_button", lambda: None)
     monkeypatch.setattr("app_utils.excel_utils.list_sheets", lambda _u: ["Sheet1"])
     monkeypatch.setattr(
@@ -140,13 +149,13 @@ def run_app_with_labels(monkeypatch: MonkeyPatch) -> Tuple[Dict[str, object], Di
 
     def fake_log(
         process_guid,
+        operation_cd,
         template_name,
         friendly_name,
         user_email,
         file_name_string,
         process_json,
         template_guid,
-        operation_cd,
         adhoc_headers=None,
     ):
         captured["log_adhoc"] = adhoc_headers
@@ -194,7 +203,9 @@ def test_adhoc_labels_propagate(monkeypatch: MonkeyPatch) -> None:
 
 def test_default_label_updates_on_mapping(monkeypatch: MonkeyPatch) -> None:
     st = setup_header_env(monkeypatch)
-    layer = HeaderLayer(type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)])
+    layer = HeaderLayer(
+        type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)]
+    )
     st.session_state["src_ADHOC_INFO1"] = "A"
     header_step.render(layer, 0)
     assert st.session_state["header_adhoc_headers"]["ADHOC_INFO1"] == "A"
@@ -203,7 +214,9 @@ def test_default_label_updates_on_mapping(monkeypatch: MonkeyPatch) -> None:
 
 def test_custom_label_persists(monkeypatch: MonkeyPatch) -> None:
     st = setup_header_env(monkeypatch)
-    layer = HeaderLayer(type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)])
+    layer = HeaderLayer(
+        type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)]
+    )
     st.session_state["src_ADHOC_INFO1"] = "A"
     header_step.render(layer, 0)
     st.session_state["adhoc_label_ADHOC_INFO1"] = "Custom"
@@ -216,7 +229,9 @@ def test_custom_label_persists(monkeypatch: MonkeyPatch) -> None:
 
 def test_label_updates_after_multiple_source_changes(monkeypatch: MonkeyPatch) -> None:
     st = setup_header_env(monkeypatch)
-    layer = HeaderLayer(type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)])
+    layer = HeaderLayer(
+        type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)]
+    )
     st.session_state["src_ADHOC_INFO1"] = "A"
     header_step.render(layer, 0)
     assert st.session_state["header_adhoc_headers"]["ADHOC_INFO1"] == "A"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,278 +10,314 @@ from app_utils import azure_sql
 
 
 def test_cli_basic(monkeypatch, tmp_path: Path):
-    tpl = Path('tests/fixtures/simple-template.json')
-    src = Path('tests/fixtures/simple.csv')
-    out = tmp_path / 'out.json'
+    tpl = Path("tests/fixtures/simple-template.json")
+    src = Path("tests/fixtures/simple.csv")
+    out = tmp_path / "out.json"
     captured: dict[str, object] = {}
 
-    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, operation_cd, adhoc_headers=None):
+    def fake_log(
+        process_guid,
+        operation_cd,
+        template_name,
+        friendly_name,
+        user_email,
+        file_name_string,
+        process_json,
+        template_guid,
+        adhoc_headers=None,
+    ):
         captured.update(
             {
-                'process_guid': process_guid,
-                'template_name': template_name,
-                'friendly_name': friendly_name,
-                'user_email': user_email,
-                'file_name_string': file_name_string,
-                'process_json': process_json,
-                'template_guid': template_guid,
-                'operation_cd': operation_cd,
-                'adhoc_headers': adhoc_headers,
+                "process_guid": process_guid,
+                "template_name": template_name,
+                "friendly_name": friendly_name,
+                "user_email": user_email,
+                "file_name_string": file_name_string,
+                "process_json": process_json,
+                "template_guid": template_guid,
+                "operation_cd": operation_cd,
+                "adhoc_headers": adhoc_headers,
             }
         )
 
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', fake_log)
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py', str(tpl), str(src), str(out), '--user-email', 'user@example.com'
-    ])
+    monkeypatch.setattr(azure_sql, "log_mapping_process", fake_log)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cli.py", str(tpl), str(src), str(out), "--user-email", "user@example.com"],
+    )
     cli.main()
 
     data = json.loads(out.read_text())
-    header_layer = data['layers'][0]
-    fields = {f['key']: f.get('source') for f in header_layer['fields']}
-    assert fields['Name'] == 'Name'
-    assert fields['Value'] == 'Value'
-    assert data['process_guid'] == captured['process_guid']
-    assert captured['template_name'] == tpl.stem
-    assert captured['friendly_name'] == 'simple-template'
-    assert captured['user_email'] == 'user@example.com'
-    assert captured['file_name_string'] == tpl.name
-    assert captured['operation_cd'] is None
+    header_layer = data["layers"][0]
+    fields = {f["key"]: f.get("source") for f in header_layer["fields"]}
+    assert fields["Name"] == "Name"
+    assert fields["Value"] == "Value"
+    assert data["process_guid"] == captured["process_guid"]
+    assert captured["template_name"] == tpl.stem
+    assert captured["friendly_name"] == "simple-template"
+    assert captured["user_email"] == "user@example.com"
+    assert captured["file_name_string"] == tpl.name
+    assert captured["operation_cd"] is None
 
 
 def test_cli_csv_output(monkeypatch, tmp_path: Path):
-    tpl = Path('tests/fixtures/simple-template.json')
-    src = Path('tests/fixtures/simple.csv')
-    out_json = tmp_path / 'out.json'
-    out_csv = tmp_path / 'out.csv'
+    tpl = Path("tests/fixtures/simple-template.json")
+    src = Path("tests/fixtures/simple.csv")
+    out_json = tmp_path / "out.json"
+    out_csv = tmp_path / "out.csv"
 
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
-    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py',
-        str(tpl),
-        str(src),
-        str(out_json),
-        '--csv-output',
-        str(out_csv),
-    ])
+    monkeypatch.setattr(azure_sql, "log_mapping_process", lambda *a, **k: None)
+    monkeypatch.setattr(azure_sql, "derive_adhoc_headers", lambda df: {})
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cli.py",
+            str(tpl),
+            str(src),
+            str(out_json),
+            "--csv-output",
+            str(out_csv),
+        ],
+    )
     cli.main()
 
     data = json.loads(out_json.read_text())
     content = out_csv.read_text().strip().splitlines()
-    assert content[0] == 'Name,Value'
-    assert content[1] == 'Alice,1'
-    assert data['process_guid']
+    assert content[0] == "Name,Value"
+    assert content[1] == "Alice,1"
+    assert data["process_guid"]
 
 
 def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
-    tpl = Path('templates/pit-bid.json')
-    src = tmp_path / 'src.csv'
-    src.write_text('Lane ID,Bid Volume\nL1,5\n')
-    out_json = tmp_path / 'out.json'
-    out_csv = tmp_path / 'out.csv'
+    tpl = Path("templates/pit-bid.json")
+    src = tmp_path / "src.csv"
+    src.write_text("Lane ID,Bid Volume\nL1,5\n")
+    out_json = tmp_path / "out.json"
+    out_csv = tmp_path / "out.csv"
 
     captured: dict[str, object] = {}
 
     def fake_insert(df, op, cust, ids, guid, adhoc_headers):
-        captured['cols'] = list(df.columns)
-        captured['op'] = op
-        captured['cust'] = cust
-        captured['ids'] = ids
-        captured['guid'] = guid
-        captured['adhoc'] = adhoc_headers
+        captured["cols"] = list(df.columns)
+        captured["op"] = op
+        captured["cust"] = cust
+        captured["ids"] = ids
+        captured["guid"] = guid
+        captured["adhoc"] = adhoc_headers
         return len(df)
-    monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
-    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
+
+    monkeypatch.setattr(azure_sql, "insert_pit_bid_rows", fake_insert)
+    monkeypatch.setattr(azure_sql, "derive_adhoc_headers", lambda df: {})
     monkeypatch.setattr(
-        'app_utils.postprocess_runner.get_pit_url_payload', lambda op_cd: {}
+        "app_utils.postprocess_runner.get_pit_url_payload", lambda op_cd: {}
     )
     monkeypatch.setattr(
         cli,
-        'run_postprocess_if_configured',
+        "run_postprocess_if_configured",
         lambda tpl_obj, df, guid, customer_name, operation_code=None: ([], None),
     )
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py',
-        str(tpl),
-        str(src),
-        str(out_json),
-        '--csv-output',
-        str(out_csv),
-        '--operation-code',
-        'OP',
-        '--customer-name',
-        'Cust',
-        '--customer-id',
-        '1',
-        '--customer-id',
-        '2',
-    ])
+    monkeypatch.setattr(azure_sql, "log_mapping_process", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cli.py",
+            str(tpl),
+            str(src),
+            str(out_json),
+            "--csv-output",
+            str(out_csv),
+            "--operation-code",
+            "OP",
+            "--customer-name",
+            "Cust",
+            "--customer-id",
+            "1",
+            "--customer-id",
+            "2",
+        ],
+    )
 
     cli.main()
     out = capsys.readouterr().out
     data = json.loads(out_json.read_text())
-    assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
-    assert captured['op'] == 'OP'
-    assert captured['cust'] == 'Cust'
-    assert captured['ids'] == ['1', '2']
-    assert 'Lane ID' in captured['cols']
-    assert captured['guid']
-    assert data['process_guid'] == captured['guid']
+    assert "Inserted 1 rows into RFP_OBJECT_DATA" in out
+    assert captured["op"] == "OP"
+    assert captured["cust"] == "Cust"
+    assert captured["ids"] == ["1", "2"]
+    assert "Lane ID" in captured["cols"]
+    assert captured["guid"]
+    assert data["process_guid"] == captured["guid"]
 
 
 def test_cli_sql_insert_no_ids(monkeypatch, tmp_path: Path, capsys):
-    tpl = Path('templates/pit-bid.json')
-    src = tmp_path / 'src.csv'
-    src.write_text('Lane ID,Bid Volume\nL1,5\n')
-    out_json = tmp_path / 'out.json'
-    out_csv = tmp_path / 'out.csv'
+    tpl = Path("templates/pit-bid.json")
+    src = tmp_path / "src.csv"
+    src.write_text("Lane ID,Bid Volume\nL1,5\n")
+    out_json = tmp_path / "out.json"
+    out_csv = tmp_path / "out.csv"
 
     captured: dict[str, object] = {}
 
     def fake_insert(df, op, cust, ids, guid, adhoc_headers):
-        captured['ids'] = ids
+        captured["ids"] = ids
         return len(df)
 
-    monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
-    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
+    monkeypatch.setattr(azure_sql, "insert_pit_bid_rows", fake_insert)
+    monkeypatch.setattr(azure_sql, "derive_adhoc_headers", lambda df: {})
     monkeypatch.setattr(
-        'app_utils.postprocess_runner.get_pit_url_payload', lambda op_cd: {}
+        "app_utils.postprocess_runner.get_pit_url_payload", lambda op_cd: {}
     )
     monkeypatch.setattr(
         cli,
-        'run_postprocess_if_configured',
+        "run_postprocess_if_configured",
         lambda tpl_obj, df, guid, customer_name, operation_code=None: ([], None),
     )
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py',
-        str(tpl),
-        str(src),
-        str(out_json),
-        '--csv-output',
-        str(out_csv),
-        '--operation-code',
-        'OP',
-        '--customer-name',
-        'Cust',
-    ])
+    monkeypatch.setattr(azure_sql, "log_mapping_process", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cli.py",
+            str(tpl),
+            str(src),
+            str(out_json),
+            "--csv-output",
+            str(out_csv),
+            "--operation-code",
+            "OP",
+            "--customer-name",
+            "Cust",
+        ],
+    )
 
     cli.main()
     out = capsys.readouterr().out
     data = json.loads(out_json.read_text())
-    assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
-    assert captured['ids'] is None
-    assert data['process_guid']
+    assert "Inserted 1 rows into RFP_OBJECT_DATA" in out
+    assert captured["ids"] is None
+    assert data["process_guid"]
+
 
 def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path, capsys):
-    tpl = Path('templates/pit-bid.json')
-    src = tmp_path / 'src.csv'
-    src.write_text('Lane ID,Bid Volume\nL1,5\n')
-    out_json = tmp_path / 'out.json'
-    out_csv = tmp_path / 'out.csv'
+    tpl = Path("templates/pit-bid.json")
+    src = tmp_path / "src.csv"
+    src.write_text("Lane ID,Bid Volume\nL1,5\n")
+    out_json = tmp_path / "out.json"
+    out_csv = tmp_path / "out.csv"
 
     def fake_insert(df, op, cust, ids, guid, adhoc_headers):
         return len(df)
 
     captured: dict[str, object] = {}
 
-    def fake_postprocess(
-        tpl_obj, df, process_guid, cust_name, op_cd
-    ):
-        captured['op'] = op_cd
-        captured['cust'] = cust_name
-        captured['guid'] = process_guid
-        return ['POST https://example.com/hook', 'Done'], {'foo': 'bar'}
+    def fake_postprocess(tpl_obj, df, process_guid, cust_name, op_cd):
+        captured["op"] = op_cd
+        captured["cust"] = cust_name
+        captured["guid"] = process_guid
+        return ["POST https://example.com/hook", "Done"], {"foo": "bar"}
 
-    monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
-    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
-    monkeypatch.setattr(cli, 'run_postprocess_if_configured', fake_postprocess)
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py',
-        str(tpl),
-        str(src),
-        str(out_json),
-        '--csv-output',
-        str(out_csv),
-        '--operation-code',
-        'OP',
-        '--customer-name',
-        'Cust',
-    ])
+    monkeypatch.setattr(azure_sql, "insert_pit_bid_rows", fake_insert)
+    monkeypatch.setattr(azure_sql, "derive_adhoc_headers", lambda df: {})
+    monkeypatch.setattr(cli, "run_postprocess_if_configured", fake_postprocess)
+    monkeypatch.setattr(azure_sql, "log_mapping_process", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cli.py",
+            str(tpl),
+            str(src),
+            str(out_json),
+            "--csv-output",
+            str(out_csv),
+            "--operation-code",
+            "OP",
+            "--customer-name",
+            "Cust",
+        ],
+    )
 
     cli.main()
     out = capsys.readouterr().out
-    assert 'POST https://example.com/hook' in out
-    assert json.dumps({'foo': 'bar'}, indent=2) in out
+    assert "POST https://example.com/hook" in out
+    assert json.dumps({"foo": "bar"}, indent=2) in out
     data = json.loads(out_json.read_text())
-    assert captured['op'] == 'OP'
-    assert captured['cust'] == 'Cust'
-    assert captured['guid']
-    assert data['process_guid'] == captured['guid']
+    assert captured["op"] == "OP"
+    assert captured["cust"] == "Cust"
+    assert captured["guid"]
+    assert data["process_guid"] == captured["guid"]
 
 
 def test_cli_runs_without_customer_id(monkeypatch, tmp_path: Path):
-    tpl = Path('templates/pit-bid.json')
-    src = tmp_path / 'src.csv'
-    src.write_text('Lane ID,Bid Volume\nL1,5\n')
-    out_json = tmp_path / 'out.json'
+    tpl = Path("templates/pit-bid.json")
+    src = tmp_path / "src.csv"
+    src.write_text("Lane ID,Bid Volume\nL1,5\n")
+    out_json = tmp_path / "out.json"
 
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py',
-        str(tpl),
-        str(src),
-        str(out_json),
-        '--operation-code',
-        'OP',
-        '--customer-name',
-        'Cust',
-    ])
+    monkeypatch.setattr(azure_sql, "log_mapping_process", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cli.py",
+            str(tpl),
+            str(src),
+            str(out_json),
+            "--operation-code",
+            "OP",
+            "--customer-name",
+            "Cust",
+        ],
+    )
 
     cli.main()
     assert out_json.exists()
 
+
 def test_cli_sql_insert_without_customer_id(
     monkeypatch, tmp_path: Path, capsys
 ) -> None:
-    tpl = Path('templates/pit-bid.json')
-    src = tmp_path / 'src.csv'
-    src.write_text('Lane ID,Bid Volume\nL1,5\n')
-    out_json = tmp_path / 'out.json'
-    out_csv = tmp_path / 'out.csv'
+    tpl = Path("templates/pit-bid.json")
+    src = tmp_path / "src.csv"
+    src.write_text("Lane ID,Bid Volume\nL1,5\n")
+    out_json = tmp_path / "out.json"
+    out_csv = tmp_path / "out.csv"
 
     captured: dict[str, object] = {}
 
     def fake_insert(df, op, cust, ids, guid, adhoc_headers):
-        captured['ids'] = ids
+        captured["ids"] = ids
         return len(df)
 
-    monkeypatch.setattr(azure_sql, 'insert_pit_bid_rows', fake_insert)
-    monkeypatch.setattr(azure_sql, 'derive_adhoc_headers', lambda df: {})
+    monkeypatch.setattr(azure_sql, "insert_pit_bid_rows", fake_insert)
+    monkeypatch.setattr(azure_sql, "derive_adhoc_headers", lambda df: {})
     monkeypatch.setattr(
         cli,
-        'run_postprocess_if_configured',
+        "run_postprocess_if_configured",
         lambda tpl_obj, df, guid, customer_name, operation_code=None: ([], None),
     )
-    monkeypatch.setattr(azure_sql, 'log_mapping_process', lambda *a, **k: None)
-    monkeypatch.setattr(sys, 'argv', [
-        'cli.py',
-        str(tpl),
-        str(src),
-        str(out_json),
-        '--csv-output',
-        str(out_csv),
-        '--operation-code',
-        'OP',
-        '--customer-name',
-        'Cust',
-    ])
+    monkeypatch.setattr(azure_sql, "log_mapping_process", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cli.py",
+            str(tpl),
+            str(src),
+            str(out_json),
+            "--csv-output",
+            str(out_csv),
+            "--operation-code",
+            "OP",
+            "--customer-name",
+            "Cust",
+        ],
+    )
 
     cli.main()
     out = capsys.readouterr().out
-    assert 'Inserted 1 rows into RFP_OBJECT_DATA' in out
-    assert captured['ids'] is None
-
+    assert "Inserted 1 rows into RFP_OBJECT_DATA" in out
+    assert captured["ids"] is None

--- a/tests/test_log_mapping_process.py
+++ b/tests/test_log_mapping_process.py
@@ -25,34 +25,34 @@ def _fake_conn(captured: dict):
     return FakeConn()
 
 
-@pytest.mark.parametrize("payload", [{"a": 1}, "{\"a\": 1}"])
+@pytest.mark.parametrize("payload", [{"a": 1}, '{"a": 1}'])
 def test_log_mapping_process(monkeypatch, payload):
     captured: dict = {}
     monkeypatch.setattr(azure_sql, "_connect", lambda: _fake_conn(captured))
     adhoc = {"ADHOC_INFO1": "Foo"}
     azure_sql.log_mapping_process(
         "proc",
+        "OP",
         "template-name",
         "Friendly",
         "user@example.com",
         "file.csv",
         payload,
         "tmpl-guid",
-        "OP",
         adhoc,
     )
     assert "MAPPING_AGENT_PROCESSES" in captured["query"]
     assert "OPERATION_CD" in captured["query"]
     params = captured["params"]
     assert params[0] == "proc"
-    assert params[1] == "template-name"
-    assert params[2] == "Friendly"
-    assert params[3] == "user@example.com"
-    assert isinstance(params[4], datetime)
-    assert params[5] == "file.csv"
-    stored = json.loads(params[6])
+    assert params[1] == "OP"
+    assert params[2] == "template-name"
+    assert params[3] == "Friendly"
+    assert params[4] == "user@example.com"
+    assert isinstance(params[5], datetime)
+    assert params[6] == "file.csv"
+    stored = json.loads(params[7])
     expected = json.loads(payload) if isinstance(payload, str) else payload
     expected["adhoc_headers"] = adhoc
     assert stored == expected
-    assert params[7] == "tmpl-guid"
-    assert params[8] == "OP"
+    assert params[8] == "tmpl-guid"

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -5,13 +5,17 @@ from pathlib import Path
 import sys
 import pandas as pd
 
+
 class DummyContainer:
     def __enter__(self):
         return self
+
     def __exit__(self, *exc):
         pass
+
     def markdown(self, *a, **k):
         pass
+
     def progress(self, *a, **k):
         pass
 
@@ -25,6 +29,7 @@ class DummyColumn:
 
     def button(self, *a, **k):
         return False
+
 
 class DummySidebar:
     def __init__(self, st):
@@ -44,14 +49,19 @@ class DummySidebar:
         if key:
             self.st.session_state[key] = choice
         return choice
+
     def empty(self):
         return DummyContainer()
+
     def write(self, *a, **k):
         pass
+
     def info(self, *a, **k):
         pass
+
     def button(self, *a, **k):
         return False
+
 
 class DummyStreamlit:
     def __init__(self, button_sequence: list[set[str]] | None = None):
@@ -66,22 +76,30 @@ class DummyStreamlit:
         self.secrets = {}
         self.button_sequence = button_sequence or []
         self.run_idx = 0
+
     def set_page_config(self, *a, **k):
         pass
+
     def title(self, *a, **k):
         pass
+
     header = subheader = error = write = warning = caption = title
+
     def info(self, msg, *a, **k):
         self.info_messages.append(msg)
+
     def success(self, msg, *a, **k):
         self.success_messages.append(msg)
+
     def selectbox(self, label, options, index=0, key=None, **k):
         choice = options[index] if options and index is not None else None
         if key:
             self.session_state[key] = choice
         return choice
+
     def file_uploader(self, *a, **k):
         return types.SimpleNamespace(name="upload.csv")
+
     def button(self, label, *a, **k):
         presses = (
             self.button_sequence[self.run_idx]
@@ -91,34 +109,46 @@ class DummyStreamlit:
         if k.get("disabled"):
             return False
         return label in presses
+
     def spinner(self, msg, *a, **k):
         class _C(DummyContainer):
             def __enter__(self_inner):
                 self.spinner_messages.append(msg)
                 return self_inner
+
         return _C()
+
     def empty(self):
         return DummyContainer()
+
     def rerun(self):
         pass
 
     def next_run(self) -> None:
         self.run_idx += 1
+
     def markdown(self, text, *a, **k):
         self.markdown_calls.append(text)
+
     def link_button(self, label, url, *a, **k):
         self.link_button_calls.append((label, url))
         return False
+
     def download_button(self, *a, **k):
         pass
+
     def json(self, *a, **k):  # type: ignore[override]
         pass
+
     def dataframe(self, data, *a, **k):  # type: ignore[override]
         self.dataframe_calls.append(data)
+
     def cache_data(self, *a, **k):
         def wrap(func):
             return func
+
         return wrap
+
     def multiselect(self, label, options, default=None, key=None, **k):
         if key and key in self.session_state:
             return self.session_state[key]
@@ -126,6 +156,7 @@ class DummyStreamlit:
         if key:
             self.session_state[key] = sel
         return sel
+
     def columns(self, spec, **kwargs):
         n = len(spec) if isinstance(spec, (list, tuple)) else spec
         return [DummyColumn() for _ in range(n)]
@@ -140,7 +171,9 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     monkeypatch.setenv("DISABLE_AUTH", "1")
     monkeypatch.setenv("CLIENT_DEST_SITE", "https://tenant.sharepoint.com/sites/demo")
     monkeypatch.setenv("CLIENT_DEST_FOLDER_PATH", "docs/folder with spaces")
-    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setitem(
+        sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None)
+    )
     monkeypatch.setattr("auth.logout_button", lambda: None)
     monkeypatch.setattr("app_utils.excel_utils.list_sheets", lambda _u: ["Sheet1"])
     monkeypatch.setattr(
@@ -176,15 +209,16 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
         lambda df, op, cust, ids, guid, adhoc: len(df),
     )
     monkeypatch.setattr("app_utils.azure_sql.derive_adhoc_headers", lambda df: {})
+
     def fake_log(
         process_guid,
+        operation_cd,
         template_name,
         friendly_name,
         user_email,
         file_name_string,
         process_json,
         template_guid,
-        operation_cd,
         adhoc_headers=None,
     ):
         called["log_guid"] = process_guid
@@ -192,6 +226,7 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
         called["log_friendly"] = friendly_name
         called["log_email"] = user_email
         called["log_file"] = file_name_string
+
     monkeypatch.setattr("app_utils.azure_sql.log_mapping_process", fake_log)
     called: dict[str, object] = {}
 
@@ -214,21 +249,25 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     tpl_data = json.loads(tpl_path.read_text())
     tpl_data["postprocess"] = {"url": "https://example.com"}
     orig_read = Path.read_text
+
     def fake_read(self, *a, **k):
         if self == tpl_path:
             return json.dumps(tpl_data)
         return orig_read(self, *a, **k)
+
     monkeypatch.setattr(Path, "read_text", fake_read)
-    st.session_state.update({
-        "selected_template_file": tpl_path.name,
-        "template": tpl_data,
-        "template_name": "PIT BID",
-        "current_template": "PIT BID",
-        "customer_name": "Customer",
-        "layer_confirmed_0": True,
-        "customer_name": "Cust",
-        "customer_ids": ["1"],
-    })
+    st.session_state.update(
+        {
+            "selected_template_file": tpl_path.name,
+            "template": tpl_data,
+            "template_name": "PIT BID",
+            "current_template": "PIT BID",
+            "customer_name": "Customer",
+            "layer_confirmed_0": True,
+            "customer_name": "Cust",
+            "customer_ids": ["1"],
+        }
+    )
     sys.modules.pop("app", None)
     importlib.import_module("app")
     st.next_run()
@@ -253,8 +292,7 @@ def test_sharepoint_link_displayed(monkeypatch):
     _, _, st = run_app(monkeypatch)
     assert any("mileage and toll data" in m for m in st.spinner_messages)
     assert any(
-        url
-        == "https://tenant.sharepoint.com/sites/demo/docs/folder%20with%20spaces"
+        url == "https://tenant.sharepoint.com/sites/demo/docs/folder%20with%20spaces"
         for _, url in st.link_button_calls
     )
 
@@ -290,6 +328,7 @@ def test_postprocess_flag_cleared_after_export(monkeypatch):
 def test_postprocess_flag_cleared_on_reset(monkeypatch):
     called, state, _ = run_app(monkeypatch)
     import app
+
     app.do_reset()
     assert "postprocess_run_clicked" not in state
 
@@ -302,7 +341,7 @@ def test_export_button_reenabled_after_completion(monkeypatch):
     st.button_sequence = [{"Generate BID"}]
     st.run_idx = 0
     import importlib, sys, app
+
     importlib.reload(sys.modules["app"])
     assert called.get("runs") == 2
     assert st.spinner_messages.count("Gathering mileage and toll data…") == 2
-


### PR DESCRIPTION
## Summary
- Reorder `azure_sql.log_mapping_process` calls so `operation_cd` is the second argument in app and CLI
- Align tests with new `log_mapping_process` signature and update fakes accordingly

## Testing
- `python -m black app.py cli.py tests/test_log_mapping_process.py tests/test_cli.py tests/test_wizard_postprocess.py tests/test_adhoc_labels.py`
- `DISABLE_AUTH=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f7e66e4c88333a2ff8d10a2bb1660