### PR TITLE
Refactor log mapping tests for operation code parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -622,13 +622,13 @@ def main():
                     )
                     azure_sql.log_mapping_process(
                         guid,
+                        st.session_state.get("operation_code"),
                         slugify(template_obj.template_name),
                         template_obj.template_name,
                         auth.get_user_email(),
                         selected_file,
                         json.dumps(final_json),
                         template_obj.template_guid,
-                        st.session_state.get("operation_code"),
                         adhoc_headers,
                     )
                     _, payload = run_postprocess_if_configured(

--- a/cli.py
+++ b/cli.py
@@ -135,13 +135,13 @@ def main() -> None:
             print(f"Inserted {rows} rows into RFP_OBJECT_DATA")
             azure_sql.log_mapping_process(
                 process_guid,
+                args.operation_code,
                 args.template.stem,
                 template.template_name,
                 args.user_email,
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
-                args.operation_code,
                 adhoc_headers,
             )
             logs_post, payload = run_postprocess_if_configured(
@@ -158,25 +158,25 @@ def main() -> None:
         else:
             azure_sql.log_mapping_process(
                 process_guid,
+                args.operation_code,
                 args.template.stem,
                 template.template_name,
                 args.user_email,
                 args.template.name,
                 json.dumps(mapped),
                 template.template_guid,
-                args.operation_code,
                 adhoc_headers,
             )
     else:
         azure_sql.log_mapping_process(
             process_guid,
+            args.operation_code,
             args.template.stem,
             template.template_name,
             args.user_email,
             args.template.name,
             json.dumps(mapped),
             template.template_guid,
-            args.operation_code,
             None,
         )
 

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -140,13 +140,13 @@ def run_app_with_labels(monkeypatch: MonkeyPatch) -> Tuple[Dict[str, object], Di
 
     def fake_log(
         process_guid,
+        operation_cd,
         template_name,
         friendly_name,
         user_email,
         file_name_string,
         process_json,
         template_guid,
-        operation_cd,
         adhoc_headers=None,
     ):
         captured["log_adhoc"] = adhoc_headers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,17 @@ def test_cli_basic(monkeypatch, tmp_path: Path):
     out = tmp_path / 'out.json'
     captured: dict[str, object] = {}
 
-    def fake_log(process_guid, template_name, friendly_name, user_email, file_name_string, process_json, template_guid, operation_cd, adhoc_headers=None):
+    def fake_log(
+        process_guid,
+        operation_cd,
+        template_name,
+        friendly_name,
+        user_email,
+        file_name_string,
+        process_json,
+        template_guid,
+        adhoc_headers=None,
+    ):
         captured.update(
             {
                 'process_guid': process_guid,

--- a/tests/test_log_mapping_process.py
+++ b/tests/test_log_mapping_process.py
@@ -32,27 +32,27 @@ def test_log_mapping_process(monkeypatch, payload):
     adhoc = {"ADHOC_INFO1": "Foo"}
     azure_sql.log_mapping_process(
         "proc",
+        "OP",
         "template-name",
         "Friendly",
         "user@example.com",
         "file.csv",
         payload,
         "tmpl-guid",
-        "OP",
         adhoc,
     )
     assert "MAPPING_AGENT_PROCESSES" in captured["query"]
     assert "OPERATION_CD" in captured["query"]
     params = captured["params"]
     assert params[0] == "proc"
-    assert params[1] == "template-name"
-    assert params[2] == "Friendly"
-    assert params[3] == "user@example.com"
-    assert isinstance(params[4], datetime)
-    assert params[5] == "file.csv"
-    stored = json.loads(params[6])
+    assert params[1] == "OP"
+    assert params[2] == "template-name"
+    assert params[3] == "Friendly"
+    assert params[4] == "user@example.com"
+    assert isinstance(params[5], datetime)
+    assert params[6] == "file.csv"
+    stored = json.loads(params[7])
     expected = json.loads(payload) if isinstance(payload, str) else payload
     expected["adhoc_headers"] = adhoc
     assert stored == expected
-    assert params[7] == "tmpl-guid"
-    assert params[8] == "OP"
+    assert params[8] == "tmpl-guid"

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -178,13 +178,13 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     monkeypatch.setattr("app_utils.azure_sql.derive_adhoc_headers", lambda df: {})
     def fake_log(
         process_guid,
+        operation_cd,
         template_name,
         friendly_name,
         user_email,
         file_name_string,
         process_json,
         template_guid,
-        operation_cd,
         adhoc_headers=None,
     ):
         called["log_guid"] = process_guid


### PR DESCRIPTION
## Summary
- Pass operation code as the second argument to `log_mapping_process`
- Align test assertions with new SQL insert order
- Update CLI and app call sites for new `log_mapping_process` signature

## Testing
- `pytest tests/test_log_mapping_process.py tests/test_cli.py tests/test_adhoc_labels.py tests/test_wizard_postprocess.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f7e67c148833382e697ffab69fb73