### PR TITLE
Add ensure_user_email helper and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -620,11 +620,16 @@ def main():
                         guid,
                         adhoc_headers,
                     )
+                    user_email = auth.ensure_user_email()
+                    if not user_email:
+                        st.warning(
+                            "User email missing; logging export as 'unknown'",
+                        )
                     azure_sql.log_mapping_process(
                         guid,
                         slugify(template_obj.template_name),
                         template_obj.template_name,
-                        auth.get_user_email(),
+                        user_email or "unknown",
                         selected_file,
                         json.dumps(final_json),
                         template_obj.template_guid,

--- a/auth.py
+++ b/auth.py
@@ -74,6 +74,10 @@ if DISABLE_AUTH:
     def get_user_email() -> str | None:  # type: ignore
         return st.session_state.get("user_email")
 
+    def ensure_user_email() -> str | None:  # type: ignore
+        """Return user email from session (dev bypass)."""
+        return st.session_state.get("user_email")
+
 else:
     # ----------------------------------------------------------------------- #
     # 2.  Real MSAL authentication                                            #
@@ -232,4 +236,12 @@ else:
                 st.rerun()
 
     def get_user_email() -> str | None:
+        return st.session_state.get("user_email")
+
+    def ensure_user_email() -> str | None:
+        """Ensure user email is available, invoking login if needed."""
+        email = st.session_state.get("user_email")
+        if email:
+            return email
+        _ensure_user()
         return st.session_state.get("user_email")

--- a/tests/test_log_mapping_process.py
+++ b/tests/test_log_mapping_process.py
@@ -1,6 +1,10 @@
-import pytest
-from datetime import datetime
+import importlib
 import json
+import sys
+from datetime import datetime
+
+import pytest
+import streamlit as st
 
 from app_utils import azure_sql
 
@@ -32,27 +36,86 @@ def test_log_mapping_process(monkeypatch, payload):
     adhoc = {"ADHOC_INFO1": "Foo"}
     azure_sql.log_mapping_process(
         "proc",
+        "OP",
         "template-name",
         "Friendly",
         "user@example.com",
         "file.csv",
         payload,
         "tmpl-guid",
-        "OP",
         adhoc,
     )
     assert "MAPPING_AGENT_PROCESSES" in captured["query"]
     assert "OPERATION_CD" in captured["query"]
     params = captured["params"]
     assert params[0] == "proc"
-    assert params[1] == "template-name"
-    assert params[2] == "Friendly"
-    assert params[3] == "user@example.com"
-    assert isinstance(params[4], datetime)
-    assert params[5] == "file.csv"
-    stored = json.loads(params[6])
+    assert params[1] == "OP"
+    assert params[2] == "template-name"
+    assert params[3] == "Friendly"
+    assert params[4] == "user@example.com"
+    assert isinstance(params[5], datetime)
+    assert params[6] == "file.csv"
+    stored = json.loads(params[7])
     expected = json.loads(payload) if isinstance(payload, str) else payload
     expected["adhoc_headers"] = adhoc
     assert stored == expected
-    assert params[7] == "tmpl-guid"
-    assert params[8] == "OP"
+    assert params[8] == "tmpl-guid"
+
+
+@pytest.mark.parametrize("recover_email", [True, False])
+def test_ensure_user_email_relogin(
+    monkeypatch: pytest.MonkeyPatch, recover_email: bool
+) -> None:
+    monkeypatch.setenv("DISABLE_AUTH", "0")
+    monkeypatch.setenv("AAD_CLIENT_ID", "cid")
+    monkeypatch.setenv("AAD_TENANT_ID", "tid")
+    monkeypatch.setenv("AAD_REDIRECT_URI", "uri")
+    st.session_state.clear()
+    if "auth" in sys.modules:
+        del sys.modules["auth"]
+    auth = importlib.import_module("auth")
+
+    called = {"flag": False}
+
+    def fake_ensure() -> None:
+        called["flag"] = True
+        if recover_email:
+            st.session_state["user_email"] = "user@example.com"
+
+    monkeypatch.setattr(auth, "_ensure_user", fake_ensure)
+
+    captured: dict[str, str] = {}
+
+    def fake_log(
+        process_guid: str,
+        operation_cd: str | None,
+        template_name: str,
+        friendly_name: str,
+        created_by: str,
+        file_name_string: str,
+        process_json: dict | str,
+        template_guid: str,
+        adhoc_headers: dict | None = None,
+    ) -> None:
+        captured["created_by"] = created_by
+
+    monkeypatch.setattr(azure_sql, "log_mapping_process", fake_log)
+
+    email = auth.ensure_user_email()
+    assert called["flag"] is True
+    created_by = email or "unknown"
+    azure_sql.log_mapping_process(
+        "proc",
+        "OP",
+        "tmpl",
+        "friendly",
+        created_by,
+        "file.csv",
+        {},
+        "tmpl-guid",
+    )
+    assert captured["created_by"] == (
+        "user@example.com" if recover_email else "unknown"
+    )
+    st.session_state.clear()
+    del sys.modules["auth"]


### PR DESCRIPTION
## Summary
- add ensure_user_email helper to reload login if session email missing
- warn and fallback to placeholder when exporting without an email
- cover new login helper and export behavior with tests

## Testing
- `pytest tests/test_log_mapping_process.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f7e95414c8333a825d78d8bc1b000