### PR TITLE
Allow forgetting header formula suggestions

### DIFF
--- a/app_utils/ui/header_utils.py
+++ b/app_utils/ui/header_utils.py
@@ -22,8 +22,8 @@ def set_field_mapping(field_key: str, idx: int, value: dict) -> None:
         st.session_state[map_key] = mapping
 
 
-def remove_formula(field_key: str, idx: int) -> None:
-    """Remove formula mapping and stored suggestion for ``field_key``."""
+def remove_formula(field_key: str, idx: int, drop_suggestion: bool = False) -> None:
+    """Remove formula mapping for ``field_key`` and optionally drop suggestion."""
     map_key = f"header_mapping_{idx}"
     mapping = st.session_state.get(map_key, {})
     info = mapping.get(field_key, {})
@@ -32,7 +32,7 @@ def remove_formula(field_key: str, idx: int) -> None:
     mapping[field_key] = info
     st.session_state[map_key] = mapping
     tpl = st.session_state.get("current_template")
-    if tpl:
+    if tpl and drop_suggestion:
         remove_suggestion(tpl, field_key, "formula")
 
 

--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -197,10 +197,17 @@ def render(layer, idx: int) -> None:
         expr_disp = mapping.get(key, {}).get("expr_display") or mapping.get(key, {}).get("expr")
         conf = mapping.get(key, {}).get("confidence")
         if expr_disp:
-            pill = row[2].columns([4, 1])
+            pill = row[2].columns([4, 1, 2])
             pill[0].markdown(f"<span class='expr-pill'>{expr_disp}</span>", unsafe_allow_html=True)
             if pill[1].button("×", key=f"rm_expr_{key}", help="Remove formula"):
-                remove_formula(key, idx)
+                remove_formula(key, idx, drop_suggestion=False)
+                st.rerun()
+            if pill[2].button(
+                "Forget suggestion",
+                key=f"forget_expr_{key}",
+                help="Remove formula and suggestion",
+            ):
+                remove_formula(key, idx, drop_suggestion=True)
                 st.rerun()
         elif conf is not None and "src" in mapping.get(key, {}):
             pct = int(round(conf * 100))


### PR DESCRIPTION
## Summary
- allow dropping stored suggestions when clearing formulas
- add "Forget suggestion" option in header mapping UI
- test removing formulas with and without forgetting suggestions

## Testing
- `pytest tests/test_header_mapping.py::test_remove_formula_keeps_suggestion tests/test_header_mapping.py::test_remove_formula_forget_suggestion -q`


------
https://chatgpt.com/codex/tasks/task_b_689f8345699483338b3866d3f388232c