### PR TITLE
Hide Template Manager for non-admin users

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,10 +111,25 @@ def do_reset(user_email: str | None = None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Helper to remove admin-only pages
+# ---------------------------------------------------------------------------
+def remove_template_manager_page() -> None:
+    """Hide Template Manager page for non-admin users."""
+    if st.session_state.get("is_admin"):
+        return
+    get_pages = getattr(st, "experimental_get_pages", None)
+    if not get_pages:
+        return
+    pages = get_pages()
+    pages.pop("pages/template_manager.py", None)
+
+
+# ---------------------------------------------------------------------------
 # 0. Page config & helpers
 # ---------------------------------------------------------------------------
 @require_login
 def main():
+    remove_template_manager_page()
     st.set_page_config(page_title="AI Mapping Agent", layout="wide")
     apply_global_css()
     st.title("AI Mapping Agent")

--- a/tests/test_remove_template_manager_page.py
+++ b/tests/test_remove_template_manager_page.py
@@ -1,0 +1,15 @@
+import streamlit as st
+
+import app
+
+
+def test_non_admin_page_removed(monkeypatch):
+    pages = {
+        "app.py": {},
+        "pages/template_manager.py": {},
+    }
+    monkeypatch.setattr(st, "experimental_get_pages", lambda: pages, raising=False)
+    st.session_state.clear()
+    st.session_state["is_admin"] = False
+    app.remove_template_manager_page()
+    assert "pages/template_manager.py" not in pages


### PR DESCRIPTION
## Summary
- Hide Template Manager page for non-admins by pruning it from `st.experimental_get_pages()` on login
- Only admins see the Template Manager page link
- Add unit test ensuring non-admins cannot access Template Manager via pages list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f8ebbde50833395f8c051d23770b9