### PR TITLE
Use confidential MSAL client and update tests

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -9,7 +9,7 @@ auth.py  –  Stand-alone + demo-bypass
 
 Environment variables
 ---------------------
-AAD_CLIENT_ID, AAD_TENANT_ID, AAD_REDIRECT_URI
+AAD_CLIENT_ID, AAD_CLIENT_SECRET, AAD_TENANT_ID, AAD_REDIRECT_URI
 AAD_EMPLOYEE_GROUP_IDS=            # optional
 AAD_EMPLOYEE_DOMAINS=ksmcpa.com,ksmta.com
 AAD_KSMTA_GROUP_IDS=cccccccc-cccc-cccc-cccc-cccccccccccc
@@ -47,6 +47,7 @@ def _get_config(name: str, default: str | None = None) -> str | None:
 # --------------------------------------------------------------------------- #
 DISABLE_AUTH = _get_config("DISABLE_AUTH", "0") == "1"
 CLIENT_ID = _get_config("AAD_CLIENT_ID")
+CLIENT_SECRET = _get_config("AAD_CLIENT_SECRET")
 TENANT_ID = _get_config("AAD_TENANT_ID")
 REDIRECT_URI = _get_config("AAD_REDIRECT_URI")
 
@@ -88,9 +89,9 @@ else:
     # ----------------------------------------------------------------------- #
     import msal  # only when auth enabled
 
-    if not all([CLIENT_ID, TENANT_ID, REDIRECT_URI]):
+    if not all([CLIENT_ID, CLIENT_SECRET, TENANT_ID, REDIRECT_URI]):
         raise RuntimeError(
-            "AAD_CLIENT_ID, AAD_TENANT_ID, and AAD_REDIRECT_URI must be set in st.secrets or environment variables."
+            "AAD_CLIENT_ID, AAD_CLIENT_SECRET, AAD_TENANT_ID, and AAD_REDIRECT_URI must be set in st.secrets or environment variables."
         )
 
     EMPLOYEE_GROUP_IDS: Set[str] = {
@@ -117,11 +118,12 @@ else:
     _FLOW_CACHE: Dict[str, Dict[str, Any]] = {}
 
     # -------------------- MSAL helpers ------------------------------------ #
-    def _build_msal_app() -> msal.PublicClientApplication:
+    def _build_msal_app() -> msal.ConfidentialClientApplication:
         if "msal_app" not in st.session_state:
-            st.session_state.msal_app = msal.PublicClientApplication(
+            st.session_state.msal_app = msal.ConfidentialClientApplication(
                 client_id=CLIENT_ID,
                 authority=AUTHORITY,
+                client_credential=CLIENT_SECRET,
             )
         return st.session_state.msal_app
 

--- a/tests/test_auth_confidential_client.py
+++ b/tests/test_auth_confidential_client.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+
+import pytest
+import streamlit as st
+import msal
+
+
+def test_build_msal_app_uses_confidential(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AAD_CLIENT_ID", "cid")
+    monkeypatch.setenv("AAD_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("AAD_TENANT_ID", "tid")
+    monkeypatch.setenv("AAD_REDIRECT_URI", "http://localhost")
+    monkeypatch.delenv("DISABLE_AUTH", raising=False)
+    st.session_state.clear()
+    if "auth" in sys.modules:
+        del sys.modules["auth"]
+
+    captured: dict[str, str] = {}
+
+    class DummyConfidential:
+        def __init__(self, client_id: str, authority: str, client_credential: str) -> None:
+            captured["client_id"] = client_id
+            captured["authority"] = authority
+            captured["client_credential"] = client_credential
+
+    monkeypatch.setattr(msal, "ConfidentialClientApplication", DummyConfidential)
+    auth = importlib.import_module("auth")
+
+    app = auth._build_msal_app()
+    assert isinstance(app, DummyConfidential)
+    assert captured == {
+        "client_id": "cid",
+        "authority": "https://login.microsoftonline.com/tid",
+        "client_credential": "secret",
+    }
+
+    st.session_state.clear()
+    del sys.modules["auth"]

--- a/tests/test_auth_query_params.py
+++ b/tests/test_auth_query_params.py
@@ -8,6 +8,7 @@ from streamlit.runtime.state.query_params import QueryParams
 
 def test_complete_flow_accepts_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AAD_CLIENT_ID", "cid")
+    monkeypatch.setenv("AAD_CLIENT_SECRET", "sec")
     monkeypatch.setenv("AAD_TENANT_ID", "tid")
     monkeypatch.setenv("AAD_REDIRECT_URI", "http://localhost")
     monkeypatch.delenv("DISABLE_AUTH", raising=False)


### PR DESCRIPTION
## Summary
- load `AAD_CLIENT_SECRET` with other Azure AD settings
- instantiate `msal.ConfidentialClientApplication` using the secret
- add tests for confidential client initialization

## Testing
- `pytest tests/test_auth_query_params.py tests/test_auth_confidential_client.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f95ae6e048333aa721e133610468b