### PR TITLE
Expose user name and display badge

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,12 @@ def main():
     apply_global_css()
     st.title("AI Mapping Agent")
 
+    name = auth.get_user_name()
+    if name:
+        st.markdown(
+            f"<div class='user-badge'>👤 {name}</div>", unsafe_allow_html=True
+        )
+
     if st.session_state.get("unsaved_changes"):
         st.warning(
             "Unsaved template changes detected. Save before leaving to keep your work."

--- a/app_utils/ui_utils.py
+++ b/app_utils/ui_utils.py
@@ -45,6 +45,17 @@ def apply_global_css() -> None:
 
         /* Optional: narrower selects when you toggle a 'compact' class */
         .compact [data-testid="stSelectbox"] { max-width: 460px; }
+
+        .user-badge {
+            position: fixed;
+            top: 8px;
+            right: 16px;
+            padding: 4px 8px;
+            border-radius: 4px;
+            background: rgba(0,0,0,0.6);
+            color: #fff;
+            z-index: 1000;
+        }
         </style>
         """,
         unsafe_allow_html=True,

--- a/tests/test_auth_dev_name.py
+++ b/tests/test_auth_dev_name.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+
+import pytest
+import streamlit as st
+
+
+def test_default_dev_user_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISABLE_AUTH", "1")
+    monkeypatch.delenv("DEV_USER_NAME", raising=False)
+    monkeypatch.delenv("DEV_USER_EMAIL", raising=False)
+    st.session_state.clear()
+    for mod in ["auth"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    auth = importlib.import_module("auth")
+    try:
+        assert auth.get_user_name() == "pete.richards"
+    finally:
+        st.session_state.clear()
+        del sys.modules["auth"]

--- a/tests/test_user_badge_display.py
+++ b/tests/test_user_badge_display.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from typing import List
+
+import pytest
+import streamlit as st
+
+
+def test_user_badge_display(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISABLE_AUTH", "1")
+    st.session_state.clear()
+    st.session_state["user_name"] = "Alice"
+
+    calls: List[str] = []
+
+    def fake_markdown(body: str, *args, **kwargs) -> None:
+        calls.append(body)
+
+    monkeypatch.setattr(st, "markdown", fake_markdown)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+
+    for mod in ["auth", "app"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    app = importlib.import_module("app")
+    monkeypatch.setattr(app, "fetch_operation_codes", lambda: [])
+
+    app.main()
+
+    assert any("user-badge" in html and "Alice" in html for html in calls)


### PR DESCRIPTION
## Summary
- Seed `user_name` in dev mode and expose via new `get_user_name()` helper
- Style and render fixed-position user badge in the app header
- Add tests for dev username default and badge rendering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f9ccbe7bc8333bbe25f25b8bf090d