### PR TITLE
Handle missing MSAL flow cache after rerun

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -142,7 +142,8 @@ else:
 
     def _initiate_flow() -> str:
         """Start MSAL auth-code flow (once per session) and return login URL."""
-        if "msal_state" not in st.session_state:
+        state = st.session_state.get("msal_state")
+        if not state or state not in _FLOW_CACHE:
             app = _build_msal_app()
             flow = app.initiate_auth_code_flow(
                 scopes=SCOPE,
@@ -151,7 +152,7 @@ else:
             )
             st.session_state["msal_state"] = flow["state"]
             _FLOW_CACHE[flow["state"]] = flow
-        state = st.session_state["msal_state"]
+            state = flow["state"]
         return _FLOW_CACHE[state]["auth_uri"]
 
     def _complete_flow() -> None:

--- a/tests/test_auth_flow_rebuilds_after_rerun.py
+++ b/tests/test_auth_flow_rebuilds_after_rerun.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+
+import pytest
+import streamlit as st
+
+
+def test_initiate_flow_rebuilds_after_rerun(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AAD_CLIENT_ID", "cid")
+    monkeypatch.setenv("AAD_CLIENT_SECRET", "sec")
+    monkeypatch.setenv("AAD_TENANT_ID", "tid")
+    monkeypatch.setenv("AAD_REDIRECT_URI", "http://localhost")
+    monkeypatch.delenv("DISABLE_AUTH", raising=False)
+    st.session_state.clear()
+    if "auth" in sys.modules:
+        del sys.modules["auth"]
+    auth = importlib.import_module("auth")
+
+    class DummyApp:
+        def __init__(self) -> None:
+            self.count = 0
+
+        def initiate_auth_code_flow(self, *a, **k):  # pragma: no cover - simple stub
+            self.count += 1
+            return {"state": f"s{self.count}", "auth_uri": f"http://login/{self.count}"}
+
+    dummy_app = DummyApp()
+    monkeypatch.setattr(auth, "_build_msal_app", lambda: dummy_app)
+
+    url1 = auth._initiate_flow()
+    assert url1
+    assert st.session_state["msal_state"] in auth._FLOW_CACHE
+
+    auth._FLOW_CACHE.clear()
+
+    url2 = auth._initiate_flow()
+    assert url2
+    assert st.session_state["msal_state"] in auth._FLOW_CACHE
+
+    st.session_state.clear()
+    del sys.modules["auth"]


### PR DESCRIPTION
## Summary
- regenerate MSAL auth flow if cache cleared but session state remains
- add regression test verifying auth flow rebuilds on rerun

## Testing
- `pytest tests/test_auth_* -q`


------
https://chatgpt.com/codex/tasks/task_b_689fa32c48608333afad440f903b2845