### PR TITLE
Handle stale MSAL auth state

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -142,16 +142,17 @@ else:
 
     def _initiate_flow() -> str:
         """Start MSAL auth-code flow (once per session) and return login URL."""
-        if "msal_state" not in st.session_state:
+        state: str | None = st.session_state.get("msal_state")
+        if not state or state not in _FLOW_CACHE:
             app = _build_msal_app()
             flow = app.initiate_auth_code_flow(
                 scopes=SCOPE,
                 redirect_uri=REDIRECT_URI,
                 prompt="select_account",
             )
-            st.session_state["msal_state"] = flow["state"]
-            _FLOW_CACHE[flow["state"]] = flow
-        state = st.session_state["msal_state"]
+            state = flow["state"]
+            _FLOW_CACHE[state] = flow
+            st.session_state["msal_state"] = state
         return _FLOW_CACHE[state]["auth_uri"]
 
     def _complete_flow() -> None:
@@ -160,7 +161,7 @@ else:
             return  # not an auth return
         state = query["state"]
         flow = _FLOW_CACHE.pop(state, None)
-        if not flow:
+        if flow is None:
             st.error("Authentication session expired. Please sign in again.")
             st.session_state.pop("msal_state", None)
             return


### PR DESCRIPTION
## Summary
- Reset MSAL auth code flow when session state is missing from cache
- Clear stored msal_state if flow lookup fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689fa28c13648333b342a86f06df6f52