### PR TITLE
enhance login and logout UI with user email display

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,6 +133,9 @@ def main():
     st.set_page_config(page_title="AI Mapping Agent", layout="wide")
     apply_global_css()
     st.title("AI Mapping Agent")
+    user_email = get_user_email()
+    if user_email:
+        st.caption(f"Signed in as {user_email}")
 
     if st.session_state.get("unsaved_changes"):
         st.warning(
@@ -151,7 +154,6 @@ def main():
 
     st.session_state.setdefault("upload_data_file_key", str(uuid.uuid4()))
 
-    user_email = get_user_email()
     if user_email and "selected_template_file" not in st.session_state:
         last = get_last_template(user_email)
         if last:

--- a/auth.py
+++ b/auth.py
@@ -210,7 +210,14 @@ else:
             return
 
         login_url = _initiate_flow()
-        st.link_button("🔒 Sign in with Microsoft", login_url)
+        st.title("AI Mapping Agent")
+        st.subheader("Please sign in")
+        st.link_button(
+            "🔒 Sign in with Microsoft",
+            login_url,
+            type="primary",
+            use_container_width=True,
+        )
         st.stop()
 
     def require_login(func):
@@ -256,7 +263,12 @@ else:
 
     def logout_button() -> None:
         with st.sidebar:
-            if st.button("↩️ Sign out"):
+            email: str | None = st.session_state.get("user_email")
+            if email:
+                st.caption(f"Signed in as {email}")
+            if st.button(
+                "↩️ Sign out", type="primary", use_container_width=True
+            ):
                 for k in [
                     "user_email",
                     "user_name",


### PR DESCRIPTION
## Summary
- polish login screen with title and prominent sign-in button
- show signed-in user's email and provide styled sign-out control
- expose current user's email in main app header

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_689faa66c4188333a8f1e1d3172accee