### PR TITLE
Use empty list for customer ID session state

### DIFF
--- a/app.py
+++ b/app.py
@@ -313,7 +313,7 @@ def main():
                 st.dataframe(df.head())
 
     customer_valid = True
-    st.session_state.setdefault("customer_ids", None)
+    st.session_state.setdefault("customer_ids", [])
 
     if hasattr(st, "divider"):
         if hasattr(st, "divider"):
@@ -392,7 +392,7 @@ def main():
                     customer_name = new_name.strip().title() if new_name else ""
                     st.session_state["customer_name"] = customer_name
                     st.session_state["customer_id_options"] = []
-                    st.session_state["customer_ids"] = None
+                    st.session_state["customer_ids"] = []
                     st.session_state["selected_customer"] = (
                         {"BILLTO_NAME": customer_name} if customer_name else {}
                     )
@@ -401,7 +401,7 @@ def main():
                     customer_name = selected_name
                     st.session_state["customer_name"] = customer_name
                     if selected_name and selected_name != prev_choice:
-                        st.session_state["customer_ids"] = None
+                        st.session_state["customer_ids"] = []
                 if customer_name:
                     matches = [
                         c
@@ -428,7 +428,7 @@ def main():
                                     st.session_state["customer_ids"] = billto_ids[:5]
 
                                 def deselect_all_ids() -> None:
-                                    st.session_state["customer_ids"] = None
+                                    st.session_state["customer_ids"] = []
 
                                 # Single label for both columns keeps the row visually grouped
                                 # st.markdown("**Customer ID**")
@@ -497,7 +497,7 @@ def main():
                                     )
                     else:
                         st.session_state["customer_id_options"] = []
-                        st.session_state["customer_ids"] = None
+                        st.session_state["customer_ids"] = []
                         st.info("Selected customer has no Customer IDs.")
                 else:
                     if st.session_state.get("customer_choice") != "+ New Customer":
@@ -515,7 +515,7 @@ def main():
                         st.error("Select at least one Customer ID.")
                         customer_valid = False
                 else:
-                    st.session_state["customer_ids"] = None
+                    st.session_state["customer_ids"] = []
 
     # ---------------------------------------------------------------------------
     # 5. Main wizard

--- a/auth.py
+++ b/auth.py
@@ -145,16 +145,17 @@ else:
 
     def _initiate_flow() -> str:
         """Start MSAL auth-code flow (once per session) and return login URL."""
-        if "msal_state" not in st.session_state:
+        state = st.session_state.get("msal_state")
+        if not state or state not in _FLOW_CACHE:
             app = _build_msal_app()
             flow = app.initiate_auth_code_flow(
                 scopes=SCOPE,
                 redirect_uri=REDIRECT_URI,
                 prompt="select_account",
             )
-            st.session_state["msal_state"] = flow["state"]
-            _FLOW_CACHE[flow["state"]] = flow
-        state = st.session_state["msal_state"]
+            state = flow["state"]
+            st.session_state["msal_state"] = state
+            _FLOW_CACHE[state] = flow
         return _FLOW_CACHE[state]["auth_uri"]
 
     def _complete_flow() -> None:

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -112,12 +112,14 @@ def run_app_with_labels(
     monkeypatch: MonkeyPatch,
 ) -> Tuple[Dict[str, object], Dict[str, object]]:
     st = DummyStreamlit([{"Generate PIT"}])
+    st.session_state.clear()
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setenv("DISABLE_AUTH", "1")
     monkeypatch.setitem(
         sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None)
     )
     monkeypatch.setattr("auth.logout_button", lambda: None)
+    monkeypatch.setattr("auth.ensure_user_email", lambda: "test@example.com")
     monkeypatch.setattr("app_utils.excel_utils.list_sheets", lambda _u: ["Sheet1"])
     monkeypatch.setattr(
         "app_utils.excel_utils.read_tabular_file",

--- a/tests/test_customer_required.py
+++ b/tests/test_customer_required.py
@@ -213,7 +213,7 @@ def test_no_error_when_customer_has_no_ids(monkeypatch):
     st = run_app(monkeypatch, customers)
     assert st.errors == []
     assert "Customer ID" not in st.multiselect_calls
-    assert st.session_state.get("customer_ids") is None
+    assert st.session_state.get("customer_ids") == []
 
 
 def test_pit_bid_requires_customer_id(monkeypatch):


### PR DESCRIPTION
## Summary
- initialize and reset `customer_ids` session state with an empty list
- allow MSAL flow to recover when cached state is missing
- fix and extend tests for customer ID handling and adhoc labels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4a8f59fe083339fb333aad860b4e4