### PR TITLE
Ensure tabular inputs read as strings

### DIFF
--- a/app_utils/excel_utils.py
+++ b/app_utils/excel_utils.py
@@ -52,7 +52,8 @@ def _clean_columns(df: pd.DataFrame) -> pd.DataFrame:
     drop_cols = [
         c
         for c in df.columns
-        if (c.strip() == "" or c.startswith("Unnamed")) and df[c].isna().all()
+        if (c.strip() == "" or c.startswith("Unnamed"))
+        and (df[c].isna() | (df[c] == "")).all()
     ]
     if drop_cols:
         df = df.drop(columns=drop_cols)
@@ -150,11 +151,17 @@ def read_tabular_file(
 
         tmp_path = _copy_to_temp(uploaded_file, ".xlsx")
         header_row = detect_header_row(tmp_path, sheet_name)
-        df = pd.read_excel(tmp_path, header=header_row, sheet_name=sheet_name)
+        df = pd.read_excel(
+            tmp_path,
+            header=header_row,
+            sheet_name=sheet_name,
+            dtype=str,
+            keep_default_na=False,
+        )
         os.unlink(tmp_path)
     else:  # CSV
         uploaded_file.seek(0)
-        df = pd.read_csv(uploaded_file)
+        df = pd.read_csv(uploaded_file, dtype=str, keep_default_na=False)
 
     df = _clean_columns(df)
     return df, list(df.columns)

--- a/tests/test_excel_utils.py
+++ b/tests/test_excel_utils.py
@@ -20,13 +20,28 @@ def test_read_tabular_file_excel():
     with open('tests/fixtures/multi.xlsx', 'rb') as f:
         df, cols = read_tabular_file(f, sheet_name='Second')
     assert cols == ['B']
-    assert df.iloc[0]['B'] == 2
+    assert isinstance(df.iloc[0]['B'], str)
+    assert df.iloc[0]['B'] == '2'
 
 
 def test_read_tabular_file_drops_empty_columns():
     with open('tests/fixtures/blankcol.xlsx', 'rb') as f:
         df, cols = read_tabular_file(f, sheet_name='First')
     assert cols == ['A']
+
+
+def test_read_tabular_file_preserves_empty_cells():
+    import io
+
+    data = b"ZIP,Value\n12345,\n67890,1\n"
+    fake = io.BytesIO(data)
+    fake.name = "zip.csv"
+    df, cols = read_tabular_file(fake)
+    assert cols == ["ZIP", "Value"]
+    assert df.dtypes.tolist() == [object, object]
+    assert df.iloc[0]["ZIP"] == "12345"
+    assert df.iloc[0]["Value"] == ""
+    assert df.iloc[1]["Value"] == "1"
 
 
 def test_read_tabular_file_header_only():

--- a/tests/test_preview_pipeline.py
+++ b/tests/test_preview_pipeline.py
@@ -25,7 +25,7 @@ def test_preview_pipeline(tmp_path: Path) -> None:
         mapped_df = save_mapped_csv(df, preview_json, tmp_path)
     tmp_path.unlink()
     assert list(mapped_df.columns) == ["Name", "Value"]
-    assert mapped_df.iloc[0]["Value"] == 1
+    assert mapped_df.iloc[0]["Value"] == "1"
 
 
 def test_preview_pipeline_custom_label(tmp_path: Path) -> None:
@@ -96,7 +96,7 @@ def test_preview_pipeline_expression_overrides_src(tmp_path: Path) -> None:
     state = {
         "header_mapping_0": {
             "Name": {"src": "Name"},
-            "Value": {"src": "Value", "expr": "df['Value'] * 10"},
+            "Value": {"src": "Value", "expr": "df['Value'].astype(int) * 10"},
         }
     }
     preview_json = build_output_template(template, state, "dummy-guid")


### PR DESCRIPTION
## Summary
- Read Excel/CSV uploads using `dtype=str` and `keep_default_na=False` so all fields arrive as strings
- Drop unnamed columns consisting only of empty strings
- Extend tests to verify string typing and preserved empty cells; adjust expectations

## Testing
- `pytest tests/test_excel_utils.py -q`
- `pytest tests/test_preview_pipeline.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4afae4b9c8333b306ac5531446342