### PR TITLE
Render preview before SharePoint link

### DIFF
--- a/app.py
+++ b/app.py
@@ -703,12 +703,14 @@ def main():
                 nested = (payload.get("item/In_dtInputData") or [{}])[0]
                 dest_site = dest_site or nested.get("CLIENT_DEST_SITE")
                 dest_path = dest_path or nested.get("CLIENT_DEST_FOLDER_PATH")
+            sharepoint_url: str | None = None
             if dest_site and dest_path:
                 sharepoint_url = f"{dest_site.rstrip('/')}{quote(dest_path, safe='/')}"
-                st.link_button("Open SharePoint folder", sharepoint_url)
             preview_df = st.session_state.get("mapped_preview_df")
             if preview_df is not None:
                 st.dataframe(preview_df)
+            if sharepoint_url:
+                st.link_button("Open SharePoint folder", sharepoint_url)
             csv_data = st.session_state.get("mapped_csv")
 
             if csv_data:

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -345,3 +345,23 @@ def test_export_button_reenabled_after_completion(monkeypatch):
     importlib.reload(sys.modules["app"])
     assert called.get("runs") == 2
     assert st.spinner_messages.count("Gathering mileage and toll data…") == 2
+
+
+def test_sharepoint_link_after_preview(monkeypatch):
+    order: list[str] = []
+    orig_dataframe = DummyStreamlit.dataframe
+    orig_link_button = DummyStreamlit.link_button
+
+    def wrapped_dataframe(self, data, *args, **kwargs):  # type: ignore[override]
+        order.append("dataframe")
+        return orig_dataframe(self, data, *args, **kwargs)
+
+    def wrapped_link_button(self, label, url, *args, **kwargs):  # type: ignore[override]
+        order.append("link_button")
+        return orig_link_button(self, label, url, *args, **kwargs)
+
+    monkeypatch.setattr(DummyStreamlit, "dataframe", wrapped_dataframe)
+    monkeypatch.setattr(DummyStreamlit, "link_button", wrapped_link_button)
+
+    run_app(monkeypatch)
+    assert order[-2:] == ["dataframe", "link_button"]


### PR DESCRIPTION
## Summary
- Compute SharePoint URL during post-process success and render preview before linking
- Add regression test ensuring SharePoint link button appears after mapped preview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4ba70cdc48333bb416aeec3e7a83e