### PR TITLE
Include user email in PIT BID postprocess payload

### DIFF
--- a/app.py
+++ b/app.py
@@ -679,6 +679,7 @@ def main():
                         guid,
                         st.session_state.get("customer_name", ""),
                         st.session_state.get("operation_code"),
+                        user_email=user_email,
                     )
                     csv_bytes = tmp_path.read_bytes()
                     tmp_path.unlink()

--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -40,8 +40,14 @@ def run_postprocess_if_configured(
     customer_name: str,
     operation_cd: str | None = None,
     poll_interval: int = 30,
+    user_email: str | None = None,
 ) -> Tuple[List[str], Dict[str, Any] | List[Dict[str, Any]] | None]:
-    """Run optional postprocess hooks based on ``template``."""
+    """Run optional postprocess hooks based on ``template``.
+
+    For PIT BID templates, ``user_email`` (if provided) will be added to the
+    outgoing payload under ``NOTIFY_EMAIL`` at both the root level and within
+    each ``item/In_dtInputData`` entry.
+    """
 
     logs: List[str] = []
     payload: Dict[str, Any] | List[Dict[str, Any]] | None = None
@@ -90,8 +96,12 @@ def run_postprocess_if_configured(
         if not payload["item/In_dtInputData"]:
             payload["item/In_dtInputData"].append({})
         payload["item/In_dtInputData"][0]["NEW_EXCEL_FILENAME"] = fname
+        if user_email:
+            payload["NOTIFY_EMAIL"] = user_email
         for entry in payload.get("item/In_dtInputData", []):
             entry["CLIENT_DEST_FOLDER_PATH"] = CLIENT_BIDS_DEST_PATH
+            if user_email:
+                entry["NOTIFY_EMAIL"] = user_email
         if "BID-Payload" in payload:
             payload["BID-Payload"] = process_guid
         else:

--- a/cli.py
+++ b/cli.py
@@ -155,6 +155,7 @@ def main() -> None:
                 process_guid,
                 args.customer_name,
                 args.operation_code,
+                user_email=args.user_email,
             )
             for line in logs_post:
                 print(line)

--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -169,7 +169,10 @@ def run_app_with_labels(
     )
     monkeypatch.setattr(
         "app_utils.postprocess_runner.run_postprocess_if_configured",
-        lambda tpl, df, guid, op=None, cust=None: ([], None),
+        lambda tpl, df, guid, customer_name=None, operation_cd=None, user_email=None: (
+            [],
+            None,
+        ),
     )
 
     tpl_path = Path("templates/pit-bid.json")

--- a/tests/test_postprocess_runner.py
+++ b/tests/test_postprocess_runner.py
@@ -127,6 +127,7 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
         "guid",
         operation_cd='OP',
         customer_name='Cust',
+        user_email='user@example.com',
     )
     expected = 'OP - BID - Cust_20200101.xlsm'
     assert returned['item/In_dtInputData'][0]['NEW_EXCEL_FILENAME'] == expected
@@ -134,6 +135,11 @@ def test_pit_bid_posts_payload(load_env, monkeypatch):
     assert returned['CLIENT_DEST_FOLDER_PATH'] == CLIENT_BIDS_DEST_PATH
     assert all(
         item.get('CLIENT_DEST_FOLDER_PATH') == CLIENT_BIDS_DEST_PATH
+        for item in returned.get('item/In_dtInputData', [])
+    )
+    assert returned['NOTIFY_EMAIL'] == 'user@example.com'
+    assert all(
+        item.get('NOTIFY_EMAIL') == 'user@example.com'
         for item in returned.get('item/In_dtInputData', [])
     )
     assert called['url'] == tpl.postprocess.url
@@ -180,6 +186,7 @@ def test_pit_bid_posts(monkeypatch):
         "guid",
         operation_cd='OP',
         customer_name='Cust',
+        user_email='user@example.com',
     )
     assert "Payload loaded" in logs
     assert "Payload finalized" in logs
@@ -192,6 +199,11 @@ def test_pit_bid_posts(monkeypatch):
     assert returned['CLIENT_DEST_FOLDER_PATH'] == expected_path
     assert all(
         item.get('CLIENT_DEST_FOLDER_PATH') == expected_path
+        for item in returned.get('item/In_dtInputData', [])
+    )
+    assert returned['NOTIFY_EMAIL'] == 'user@example.com'
+    assert all(
+        item.get('NOTIFY_EMAIL') == 'user@example.com'
         for item in returned.get('item/In_dtInputData', [])
     )
     assert not any("ENABLE_POSTPROCESS" in msg for msg in logs)

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -230,7 +230,7 @@ def run_app(monkeypatch, button_sequence: list[set[str]] | None = None):
     monkeypatch.setattr("app_utils.azure_sql.log_mapping_process", fake_log)
     called: dict[str, object] = {}
 
-    def fake_runner(tpl, df, process_guid, *args):
+    def fake_runner(tpl, df, process_guid, *args, **kwargs):
         called["run"] = True
         called["runs"] = called.get("runs", 0) + 1
         called["guid"] = process_guid


### PR DESCRIPTION
## Summary
- Accept optional user email in postprocess runner and inject `NOTIFY_EMAIL` into PIT BID payloads
- Pass user email from app and CLI to the postprocess runner
- Test coverage for email propagation through postprocess payloads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4ba5aad188333a026dc1e4c788a26