### PR TITLE
Add Dockerfile and dockerignore for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Version control
+.git
+.gitignore
+
+# Documentation and misc
+AGENTS.md
+ROADMAP.md
+README.md
+LICENSE
+
+# Tests and docs
+tests
+docs
+
+# Caches and temporary files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.mypy_cache/
+.pytest_cache/
+*.sqlite
+
+# Development environments
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies
+COPY packages.txt .
+RUN apt-get update \
+    && ACCEPT_EULA=Y xargs -a packages.txt apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Environment defaults
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    STREAMLIT_SERVER_HEADLESS=true
+
+# Start the Streamlit app
+CMD ["streamlit", "run", "app.py", "--server.port=${PORT:-8501}", "--server.address=0.0.0.0"]


### PR DESCRIPTION
## Summary
- Add Dockerfile based on python:3.11-slim that installs system packages from packages.txt, installs requirements, copies app code, sets environment defaults, and runs Streamlit app
- Add .dockerignore to exclude version control, docs, tests, and other development artifacts from the Docker build context

## Testing
- `pytest` (fails: module import errors and missing configuration)

------
https://chatgpt.com/codex/tasks/task_b_68acedf9a614833389f5331e678c1739