### PR TITLE
Fix truncated msal requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ msal
 python-dotenv
 streamlit-tags
 msal-streamlit-authentication
-msal-streamlit-t2
+msal-streamlit-tools


### PR DESCRIPTION
## Summary
- replace truncated final entry with `msal-streamlit-tools`
- ensure each requirement line ends with newline

## Testing
- `pytest -q` *(fails: AttributeError: module 'auth' has no attribute '_build_msal_app')*


------
https://chatgpt.com/codex/tasks/task_b_68aceea0525c8333826e4b74566b9a92