### PR TITLE
Add start script and reference in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     STREAMLIT_SERVER_HEADLESS=true
 
 # Start the Streamlit app
-CMD ["streamlit", "run", "app.py", "--server.port=${PORT:-8501}", "--server.address=0.0.0.0"]
+CMD ["./start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+streamlit run app.py --server.port=${PORT:-8501} --server.address=0.0.0.0


### PR DESCRIPTION
## Summary
- add `start.sh` to launch the Streamlit app with dynamic port and host binding
- run `start.sh` from Dockerfile `CMD`

## Testing
- `pytest` *(fails: tests failing because auth module lacks attributes and Streamlit components not available)*

------
https://chatgpt.com/codex/tasks/task_b_68acf0aa1de08333b897f12f9acc1b76