### PR TITLE
Fix template manager page reference

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -121,7 +121,7 @@ def remove_template_manager_page() -> None:
     if not get_pages:
         return
     pages = get_pages()
-    pages.pop("pages/Template_Manager.py", None)
+    pages.pop("pages/template_manager.py", None)
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +146,7 @@ def main():
         save_col.button("Save Template", on_click=save_current_template)
         if st.session_state.get("is_admin"):
             mgr_col.page_link(
-                "pages/Template_Manager.py", label="Template Manager", icon="📝"
+                "pages/template_manager.py", label="Template Manager", icon="📝"
             )
 
     TEMPLATES_DIR = Path("templates")

--- a/tests/test_remove_template_manager_page.py
+++ b/tests/test_remove_template_manager_page.py
@@ -6,10 +6,10 @@ import Home
 def test_non_admin_page_removed(monkeypatch):
     pages = {
         "Home.py": {},
-        "pages/Template_Manager.py": {},
+        "pages/template_manager.py": {},
     }
     monkeypatch.setattr(st, "experimental_get_pages", lambda: pages, raising=False)
     st.session_state.clear()
     st.session_state["is_admin"] = False
     Home.remove_template_manager_page()
-    assert "pages/Template_Manager.py" not in pages
+    assert "pages/template_manager.py" not in pages


### PR DESCRIPTION
## Summary
- ensure Template Manager page is referenced in lowercase
- adjust test to match lowercase Template Manager path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app'; 29 failed, 155 passed)*
- `pytest tests/test_remove_template_manager_page.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68af37ddc7448333b61d389b2b4ac9d1