### PR TITLE
docs: fix Template Manager path reference

### DIFF
--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -3,4 +3,4 @@
 * Must validate against `/schemas/template_v2.py`.
 * Only include keys actually needed (no empty arrays).
 * Naming: `<template_name>.json` where template_name is kebab-case.
-* New templates are created via the Template Manager (see `pages/Template_Manager.py`).
+* New templates are created via the Template Manager (see `pages/template_manager.py`).


### PR DESCRIPTION
## Summary
- correct Template Manager reference in template guidelines to match file naming

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_b_68af37f5f1188333b01bdec339392b49