### PR TITLE
Handle AdHoc header resets via session flag

### DIFF
--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -145,6 +145,17 @@ def render(layer, idx: int) -> None:
         # Source | ⚙ | Expr | Template | Status | 🗑️
         row = st.columns([3, 1, 4, 3, 1, 1])
 
+        reset_flag = f"reset_src_{key}"
+        if st.session_state.pop(reset_flag, False):
+            set_field_mapping(key, idx, {})
+            st.session_state[f"src_{key}"] = ""
+            if key.startswith("ADHOC_INFO"):
+                match = re.findall(r"\d+", key)
+                default = f"AdHoc{match[0] if match else ''}"
+                adhoc_labels[key] = default
+                adhoc_autogen[key] = True
+                st.session_state[f"adhoc_label_{key}"] = default
+
         # ── Source dropdown ──────────────────────────────────────────────
         src_val = mapping.get(key, {}).get("src", "")
         new_src = row[0].selectbox(
@@ -268,13 +279,7 @@ def render(layer, idx: int) -> None:
                 st.rerun()
         elif key.startswith("ADHOC_INFO"):
             if row[5].button("↺", key=f"reset_{key}", help="Reset to default"):
-                set_field_mapping(key, idx, {})
-                st.session_state[f"src_{key}"] = ""
-                match = re.findall(r"\d+", key)
-                default = f"AdHoc{match[0] if match else ''}"
-                adhoc_labels[key] = default
-                adhoc_autogen[key] = True
-                st.session_state[f"adhoc_label_{key}"] = default
+                st.session_state[reset_flag] = True
                 st.rerun()
         else:
             row[5].markdown("")

--- a/tests/test_adhoc_reset.py
+++ b/tests/test_adhoc_reset.py
@@ -1,0 +1,36 @@
+from pytest import MonkeyPatch
+
+from schemas.template_v2 import FieldSpec, HeaderLayer
+from pages.steps import header as header_step
+from tests.test_adhoc_labels import HeaderDummyCol, setup_header_env
+
+
+def test_reset_button_clears_mapping_and_label(monkeypatch: MonkeyPatch) -> None:
+    st = setup_header_env(monkeypatch)
+    layer = HeaderLayer(
+        type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)]
+    )
+    header_step.render(layer, 0)
+    st.session_state["src_ADHOC_INFO1"] = "A"
+    header_step.set_field_mapping("ADHOC_INFO1", 0, {"src": "A"})
+    st.session_state["adhoc_label_ADHOC_INFO1"] = "Custom"
+    st.session_state["header_adhoc_headers"]["ADHOC_INFO1"] = "Custom"
+    st.session_state["header_adhoc_autogen"]["ADHOC_INFO1"] = False
+
+    def fake_button(self, label, key=None, **k):
+        if key == "reset_ADHOC_INFO1" and not self.st.session_state.get("_clicked"):
+            self.st.session_state["_clicked"] = True
+            return True
+        return False
+
+    monkeypatch.setattr(HeaderDummyCol, "button", fake_button)
+    header_step.render(layer, 0)
+    assert st.session_state.get("reset_src_ADHOC_INFO1") is True
+    header_step.render(layer, 0)
+    default = "AdHoc1"
+    assert st.session_state["header_mapping_0"]["ADHOC_INFO1"] == {}
+    assert st.session_state["src_ADHOC_INFO1"] == ""
+    assert st.session_state["header_adhoc_headers"]["ADHOC_INFO1"] == default
+    assert st.session_state["header_adhoc_autogen"]["ADHOC_INFO1"] is True
+    assert st.session_state["adhoc_label_ADHOC_INFO1"] == default
+    assert not st.session_state.get("reset_src_ADHOC_INFO1")


### PR DESCRIPTION
## Summary
- Reset AdHoc source fields via session state flag before widget creation
- Replace inline reset logic with flag + rerun
- Add regression test covering AdHoc label reset behavior

## Testing
- `pytest tests/test_adhoc_reset.py -q`
- `pytest tests/test_adhoc_labels.py -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_b_68b1b7bf064c8333a0de328665bd8009