### PR TITLE
Align Customer ID selector width with Customer name

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -437,9 +437,12 @@ def main():
                                     st.session_state["customer_ids"] = []
 
 
-                                cid_container = st.container()
+                                try:
+                                    cid_col, _ = st.columns([3, 1])
+                                except TypeError:
+                                    cid_col, _ = st.columns(2)
                                 multiselect_fn = getattr(
-                                    cid_container, "multiselect", st.multiselect
+                                    cid_col, "multiselect", st.multiselect
                                 )
                                 multiselect_fn(
                                     "Customer ID",


### PR DESCRIPTION
## Summary
- align Customer ID multiselect width with Customer name dropdown using `st.columns`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_b_68b1c19723b883339ea0069844bb6f62