### PR TITLE
Handle KSM email aliases in operation code lookup

### DIFF
--- a/app_utils/azure_sql.py
+++ b/app_utils/azure_sql.py
@@ -223,16 +223,28 @@ def fetch_operation_codes(email: str | None = None) -> List[str]:
     Falls back to the demo user when ``email`` is ``None``.
     """
     email = email or os.getenv("DEV_USER_EMAIL", "pete.richards@ksmta.com")
+    local_part, _, domain = email.partition("@")
+    domain = domain.lower()
+    alias: str | None = None
+    if domain == "ksmcpa.com":
+        alias = f"{local_part}@ksmta.com"
+    elif domain == "ksmta.com":
+        alias = f"{local_part}@ksmcpa.com"
+    emails = [email]
+    if alias:
+        emails.append(alias)
+    placeholders = ",".join("?" for _ in emails)
+    query = (
+        "SELECT DISTINCT OPERATION_CD FROM dbo.V_O365_MEMBER_OPERATIONS "
+        f"WHERE EMAIL IN ({placeholders}) AND PIT_REFRESH = 1"
+    )
     try:
         conn = _connect()
     except RuntimeError as err:  # pragma: no cover - exercised in integration
         raise RuntimeError(f"Operation code lookup failed: {err}") from err
     with conn:
         cur = conn.cursor()
-        cur.execute(
-            "SELECT OPERATION_CD FROM dbo.V_O365_MEMBER_OPERATIONS WHERE EMAIL = ? AND PIT_REFRESH = 1",
-            email,
-        )
+        cur.execute(query, *emails)
         rows = cur.fetchall()
     return sorted(row[0] for row in rows)
 


### PR DESCRIPTION
## Summary
- support ksmcpa.com/ksmta.com email aliases when fetching operation codes
- de-dupe operation codes with DISTINCT and IN clause
- cover operation-code email aliasing in tests

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'app')
- `pytest tests/test_azure_sql.py`


------
https://chatgpt.com/codex/tasks/task_b_68b1d885ba2083338108cad74df86332