### PR TITLE
Skip persisting adhoc formula suggestions

### DIFF
--- a/app_utils/ui/formula_dialog.py
+++ b/app_utils/ui/formula_dialog.py
@@ -126,17 +126,18 @@ def open_formula_dialog(df: pd.DataFrame, dialog_key: str) -> None:
             st.session_state[result_key] = expr
             st.session_state[f"{result_key}_display"] = re.sub(r"df\['([^']+)'\]", r"\1", expr)
 
-            add_suggestion(
-                {
-                    "template": st.session_state["current_template"],
-                    "field": dialog_key,
-                    "type": "formula",
-                    "formula": expr,
-                    "columns": re.findall(r"df\['([^']+)'\]", expr),
-                    "display": st.session_state[f"{result_key}_display"],
-                },
-                headers=list(df.columns),
-            )
+            if not dialog_key.upper().startswith("ADHOC_INFO"):
+                add_suggestion(
+                    {
+                        "template": st.session_state["current_template"],
+                        "field": dialog_key,
+                        "type": "formula",
+                        "formula": expr,
+                        "columns": re.findall(r"df\['([^']+)'\]", expr),
+                        "display": st.session_state[f"{result_key}_display"],
+                    },
+                    headers=list(df.columns),
+                )
             st.session_state.pop(expr_key, None)
             st.rerun()  # closes modal
 

--- a/tests/test_formula_dialog.py
+++ b/tests/test_formula_dialog.py
@@ -1,0 +1,74 @@
+import importlib
+import sys
+from typing import Any, List
+
+import pandas as pd
+
+
+class DummyColumn:
+    def __init__(self, pressed: bool = False) -> None:
+        self.pressed = pressed
+
+    def button(self, *a: Any, **k: Any) -> bool:  # pragma: no cover - trivial
+        if self.pressed and (func := k.get("on_click")):
+            func(*k.get("args", ()))
+        return self.pressed
+
+
+class DummyStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, Any] = {}
+
+    def dialog(self, *a: Any, **k: Any):  # pragma: no cover - trivial
+        def wrap(func: Any) -> Any:
+            return func
+
+        return wrap
+
+    def markdown(self, *a: Any, **k: Any) -> None:  # pragma: no cover - trivial
+        pass
+
+    def text_area(self, label: str, *, key: str, **k: Any) -> str:  # pragma: no cover
+        self.session_state.setdefault(key, "")
+        return self.session_state[key]
+
+    def info(self, *a: Any, **k: Any) -> None:  # pragma: no cover - trivial
+        pass
+
+    def error(self, *a: Any, **k: Any) -> None:  # pragma: no cover - trivial
+        pass
+
+    def dataframe(self, *a: Any, **k: Any) -> None:  # pragma: no cover - trivial
+        pass
+
+    def rerun(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def columns(self, spec: Any) -> List[DummyColumn]:
+        if isinstance(spec, int):
+            return [DummyColumn(False), DummyColumn(True)]
+        return [DummyColumn(False) for _ in spec]
+
+
+def run_dialog(monkeypatch, key: str) -> List[Any]:
+    df = pd.DataFrame({"A": [1, 2]})
+    dummy = DummyStreamlit()
+    dummy.session_state["current_template"] = "Demo"
+    dummy.session_state[f"{key}_expr_text"] = "df['A']"
+    monkeypatch.setitem(sys.modules, "streamlit", dummy)
+    sys.modules.pop("app_utils.ui.formula_dialog", None)
+    mod = importlib.import_module("app_utils.ui.formula_dialog")
+    calls: list[Any] = []
+    monkeypatch.setattr(mod, "add_suggestion", lambda *a, **k: calls.append(1))
+    mod.open_formula_dialog(df, key)
+    return calls
+
+
+def test_persist_for_standard_field(monkeypatch) -> None:
+    calls = run_dialog(monkeypatch, "Total")
+    assert calls
+
+
+def test_skip_persist_for_adhoc(monkeypatch) -> None:
+    calls = run_dialog(monkeypatch, "ADHOC_INFO1")
+    assert not calls


### PR DESCRIPTION
## Summary
- skip saving formula suggestions when editing ADHOC_INFO fields
- add tests covering persistence for standard and ADHOC fields

## Testing
- `pytest tests/test_formula_dialog.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68b8752ee4c08333be028f63d1a1ac3a