### PR TITLE
test: skip ADHOC_INFO suggestions

### DIFF
--- a/tests/test_suggestion_store.py
+++ b/tests/test_suggestion_store.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+import pytest
 from app_utils import suggestion_store
 
 
@@ -266,9 +267,16 @@ def test_delete_suggestion(monkeypatch, tmp_path):
     assert json.loads(path.read_text()) == []
 
 
-def test_skip_adhoc_info(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "existing",
+    [
+        [],
+        [{"template": "Demo", "field": "Name", "type": "direct", "formula": None, "columns": ["ColA"], "display": "ColA"}],
+    ],
+)
+def test_skip_adhoc_info(monkeypatch, tmp_path, existing):
     path = tmp_path / "mapping_suggestions.json"
-    path.write_text("[]")
+    path.write_text(json.dumps(existing))
     monkeypatch.setenv("SUGGESTION_FILE", str(path))
     importlib.reload(suggestion_store)
 
@@ -281,6 +289,6 @@ def test_skip_adhoc_info(monkeypatch, tmp_path):
         "display": "ColA",
     }
     suggestion_store.add_suggestion(s)
-    assert json.loads(path.read_text()) == []
+    assert json.loads(path.read_text()) == existing
     assert suggestion_store.get_suggestions("Demo", "ADHOC_INFO1") == []
     assert suggestion_store.get_suggestion("Demo", "ADHOC_INFO1") is None

--- a/tests/test_template_suggestions_ui.py
+++ b/tests/test_template_suggestions_ui.py
@@ -162,12 +162,12 @@ def test_dialog_state_persists_after_removal(monkeypatch, tmp_path):
     assert dummy.rerun_called
 
 
-def test_filter_out_adhoc_fields(monkeypatch, tmp_path):
+def test_edit_suggestions_skips_adhoc_info_fields(monkeypatch, tmp_path):
     dummy, _ = run_dialog(
         monkeypatch,
         tmp_path,
         template_name="PIT BID",
-        fields=[{"key": "Name"}, {"key": "ADHOC_INFO_EXTRA"}],
+        fields=[{"key": "Name"}, {"key": "ADHOC_INFO1"}],
     )
     assert dummy.subheaders == ["Name"]
     assert len(dummy.tag_calls) == 2


### PR DESCRIPTION
## Summary
- ensure suggestion store ignores ADHOC_INFO slots when saving
- verify PIT BID suggestion dialog omits ADHOC_INFO fields

## Testing
- `pytest tests/test_suggestion_store.py tests/test_template_suggestions_ui.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b88205f2748333aa9121a8341032a3