### PR TITLE
Clear ADHOC header state on column change

### DIFF
--- a/pages/steps/header.py
+++ b/pages/steps/header.py
@@ -84,9 +84,13 @@ def render(layer, idx: int) -> None:
         st.session_state[sheet_key] = sheet_name
         st.session_state[cols_key] = cols_hash
         st.session_state.pop(f"header_ai_done_{idx}", None)
+        st.session_state["header_adhoc_headers"] = {}
+        st.session_state["header_adhoc_autogen"] = {}
     else:
         st.session_state[cols_key] = cols_hash
     mapping = st.session_state[map_key]
+    for k in adhoc_keys:
+        mapping[k] = {}
 
     # List of user-added fields
     extra_key = f"header_extra_fields_{idx}"

--- a/tests/test_clear_adhoc_on_new_upload.py
+++ b/tests/test_clear_adhoc_on_new_upload.py
@@ -1,0 +1,44 @@
+import hashlib
+import pandas as pd
+from pytest import MonkeyPatch
+
+from schemas.template_v2 import FieldSpec, HeaderLayer
+from pages.steps import header as header_step
+from tests.test_adhoc_labels import setup_header_env
+
+
+def test_new_upload_clears_adhoc_mapping_and_label(monkeypatch: MonkeyPatch) -> None:
+    st = setup_header_env(monkeypatch)
+
+    def fake_read(file, sheet_name=None):
+        if file == "file1":
+            return pd.DataFrame({"A": [1]}), ["A"]
+        return pd.DataFrame({"B": [1]}), ["B"]
+
+    monkeypatch.setattr(header_step, "read_tabular_file", fake_read)
+
+    old_cols = ["A"]
+    old_hash = hashlib.sha256("|".join(old_cols).encode()).hexdigest()
+    st.session_state.update(
+        {
+            "uploaded_file": "file1",
+            "upload_sheet": "Sheet1",
+            "upload_sheets": ["Sheet1"],
+            "current_template": "demo",
+            "header_mapping_0": {"ADHOC_INFO1": {"src": "A"}},
+            "header_sheet_0": "Sheet1",
+            "header_cols_0": old_hash,
+            "header_adhoc_headers": {"ADHOC_INFO1": "Custom"},
+            "header_adhoc_autogen": {"ADHOC_INFO1": False},
+        }
+    )
+
+    st.session_state["uploaded_file"] = "file2"
+
+    layer = HeaderLayer(type="header", fields=[FieldSpec(key="ADHOC_INFO1", required=False)])
+    header_step.render(layer, 0)
+
+    assert st.session_state["header_mapping_0"]["ADHOC_INFO1"] == {}
+    assert st.session_state["header_adhoc_headers"]["ADHOC_INFO1"] == "AdHoc1"
+    assert st.session_state["header_adhoc_autogen"]["ADHOC_INFO1"] is True
+    assert st.session_state["adhoc_label_ADHOC_INFO1"] == "AdHoc1"


### PR DESCRIPTION
## Summary
- Reset `header_adhoc_headers` and `header_adhoc_autogen` when uploaded columns change
- Remove stale ADHOC mappings on render
- Test that new uploads clear ADHOC mapping and labels

## Testing
- `pytest tests/test_clear_adhoc_on_new_upload.py`

------
https://chatgpt.com/codex/tasks/task_b_68b8a41a62448333ab270e85c1ad2a9e