### PR TITLE
Skip ADHOC fields in suggestion dialog

### DIFF
--- a/app_utils/ui/suggestion_dialog.py
+++ b/app_utils/ui/suggestion_dialog.py
@@ -18,14 +18,12 @@ except Exception:  # noqa: BLE001
 from app_utils.suggestion_store import add_suggestion, delete_suggestion, get_suggestions
 
 
-def _field_names(tpl: dict, template_name: str) -> List[str]:
+def _field_names(tpl: dict, _template_name: str) -> List[str]:
     names: List[str] = []
     for layer in tpl.get("layers", []):
         for field in layer.get("fields", []):
             target = field.get("key") or field.get("target")
-            if target and not (
-                template_name == "PIT BID" and target.startswith("ADHOC_INFO")
-            ):
+            if target and not target.startswith("ADHOC_INFO"):
                 names.append(target)
     return names
 

--- a/tests/test_template_suggestions_ui.py
+++ b/tests/test_template_suggestions_ui.py
@@ -172,3 +172,16 @@ def test_edit_suggestions_skips_adhoc_info_fields(monkeypatch, tmp_path):
     assert dummy.subheaders == ["Name"]
     assert len(dummy.tag_calls) == 2
 
+
+def test_edit_suggestions_skips_adhoc_info_fields_non_pit_bid(
+    monkeypatch, tmp_path
+):
+    dummy, _ = run_dialog(
+        monkeypatch,
+        tmp_path,
+        template_name="Demo",  # any non-PIT BID template
+        fields=[{"key": "Name"}, {"key": "ADHOC_INFO2"}],
+    )
+    assert dummy.subheaders == ["Name"]
+    assert len(dummy.tag_calls) == 2
+


### PR DESCRIPTION
## Summary
- Skip ADHOC_INFO fields from suggestion dialog regardless of template
- Test that ADHOC fields are hidden for non-PIT BID templates

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'app')
- `pytest tests/test_template_suggestions_ui.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b8a5774d308333983b717019b766dd