### PR TITLE
Precompute BID filename and log before postprocess

### DIFF
--- a/tests/test_adhoc_labels.py
+++ b/tests/test_adhoc_labels.py
@@ -173,7 +173,7 @@ def run_app_with_labels(
     )
     monkeypatch.setattr(
         "app_utils.postprocess_runner.run_postprocess_if_configured",
-        lambda tpl, df, guid, customer_name=None, operation_cd=None, user_email=None: (
+        lambda tpl, df, guid, customer_name=None, operation_cd=None, user_email=None, filename=None: (
             [],
             None,
             None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,7 +116,7 @@ def test_cli_sql_insert(monkeypatch, tmp_path: Path, capsys):
     monkeypatch.setattr(
         cli,
         "run_postprocess_if_configured",
-        lambda tpl_obj, df, guid, customer_name, operation_code=None, user_email=None: (
+        lambda tpl_obj, df, guid, customer_name, operation_code=None, user_email=None, filename=None: (
             [],
             None,
             None,
@@ -179,7 +179,7 @@ def test_cli_sql_insert_no_ids(monkeypatch, tmp_path: Path, capsys):
     monkeypatch.setattr(
         cli,
         "run_postprocess_if_configured",
-        lambda tpl_obj, df, guid, customer_name, operation_code=None, user_email=None: (
+        lambda tpl_obj, df, guid, customer_name, operation_code=None, user_email=None, filename=None: (
             [],
             None,
             None,
@@ -233,6 +233,7 @@ def test_cli_postprocess_receives_codes(monkeypatch, tmp_path: Path, capsys):
         cust_name,
         op_cd,
         user_email=None,
+        filename=None,
     ):
         captured["op"] = op_cd
         captured["cust"] = cust_name
@@ -336,7 +337,7 @@ def test_cli_sql_insert_without_customer_id(
     monkeypatch.setattr(
         cli,
         "run_postprocess_if_configured",
-        lambda tpl_obj, df, guid, customer_name, operation_code=None, user_email=None: (
+        lambda tpl_obj, df, guid, customer_name, operation_code=None, user_email=None, filename=None: (
             [],
             None,
             None,

--- a/tests/test_wizard_postprocess.py
+++ b/tests/test_wizard_postprocess.py
@@ -293,7 +293,10 @@ def test_postprocess_runner_called(monkeypatch):
     assert called.get("log_guid") == called.get("guid")
     assert called.get("log_template") == "pit-bid"
     assert called.get("log_friendly") == "PIT BID"
-    assert called.get("log_file") == "pit-bid.json"
+    log_file = called.get("log_file")
+    assert isinstance(log_file, str)
+    assert log_file.startswith("ADSJ_VAN - BID - Cust_")
+    assert log_file.endswith(".xlsm")
     assert "final_json" not in state
 
 


### PR DESCRIPTION
## Summary
- precompute PIT BID output filename in Home and log mapping process before postprocessing
- add `generate_bid_filename` helper and allow `run_postprocess_if_configured` to accept an optional filename
- pass provided filename through postprocess payload

## Testing
- `pytest tests/test_adhoc_labels.py::test_adhoc_labels_propagate -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_b_68b8c1547500833385f5831174e80471