### PR TITLE
Sanitize BID filenames and add coverage

### DIFF
--- a/app_utils/postprocess_runner.py
+++ b/app_utils/postprocess_runner.py
@@ -18,9 +18,13 @@ CLIENT_BIDS_DEST_PATH: str = "/CLIENT  Downloads/Pricing Tools/Customer Bids"
 
 
 def generate_bid_filename(operation_cd: str, customer_name: str) -> str:
-    """Return sanitized PIT BID filename."""
+    """Return sanitized PIT BID filename.
+
+    Only letters, digits, hyphens and underscores are retained from
+    ``customer_name``; character casing is preserved.
+    """
     current_date = datetime.now().strftime("%Y%m%d%H%M%S%f")[:-3]
-    safe_customer = re.sub(r"[\\/]+", "", customer_name)
+    safe_customer = re.sub(r"[^A-Za-z0-9_-]", "", customer_name)
     return f"{operation_cd} - BID - {safe_customer}_{current_date}.xlsm"
 
 


### PR DESCRIPTION
## Summary
- Sanitize PIT BID filenames by removing all non-alphanumeric, hyphen, and underscore characters while preserving case
- Test that postprocess runner sanitizes customer names with forbidden characters
- Add unit tests to ensure acronyms stay uppercase and forbidden characters are stripped from filenames

## Testing
- `pytest tests/test_postprocess_runner.py`

------
https://chatgpt.com/codex/tasks/task_b_68bf3ea857a88333b6642b2beb633044